### PR TITLE
update!: modified *_case_with_sep to ignore alphabets or digits in seps

### DIFF
--- a/camel_case.go
+++ b/camel_case.go
@@ -93,11 +93,7 @@ func CamelCaseWithSep(input, seps string) string {
 	var flag uint8 = ChIsFirstOfStr
 
 	for _, ch := range input {
-		if strings.ContainsRune(seps, ch) {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfMark
-			}
-		} else if isAsciiUpperCase(ch) {
+		if isAsciiUpperCase(ch) {
 			switch flag {
 			case ChIsFirstOfStr, ChIsInFirstWord:
 				result = append(result, toAsciiLowerCase(ch))
@@ -126,9 +122,13 @@ func CamelCaseWithSep(input, seps string) string {
 				result = append(result, ch)
 				flag = ChIsOther
 			}
-		} else {
+		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
 			result = append(result, ch)
 			flag = ChIsNextOfMark
+		} else {
+			if flag != ChIsFirstOfStr {
+				flag = ChIsNextOfMark
+			}
 		}
 	}
 

--- a/cobol_case.go
+++ b/cobol_case.go
@@ -94,11 +94,7 @@ func CobolCaseWithSep(input, seps string) string {
 	var flag uint8 = ChIsFirstOfStr
 
 	for _, ch := range input {
-		if strings.ContainsRune(seps, ch) {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		} else if isAsciiUpperCase(ch) {
+		if isAsciiUpperCase(ch) {
 			switch flag {
 			case ChIsFirstOfStr:
 				result = append(result, ch)
@@ -123,7 +119,7 @@ func CobolCaseWithSep(input, seps string) string {
 				result = append(result, toAsciiUpperCase(ch))
 			}
 			flag = ChIsOther
-		} else {
+		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
 			switch flag {
 			case ChIsNextOfSepMark:
 				result = append(result, '-', ch)
@@ -131,6 +127,10 @@ func CobolCaseWithSep(input, seps string) string {
 				result = append(result, ch)
 			}
 			flag = ChIsNextOfKeepedMark
+		} else {
+			if flag != ChIsFirstOfStr {
+				flag = ChIsNextOfSepMark
+			}
 		}
 	}
 

--- a/kebab_case.go
+++ b/kebab_case.go
@@ -96,11 +96,7 @@ func KebabCaseWithSep(input, seps string) string {
 	var flag uint8 = ChIsFirstOfStr
 
 	for _, ch := range input {
-		if strings.ContainsRune(seps, ch) {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		} else if isAsciiUpperCase(ch) {
+		if isAsciiUpperCase(ch) {
 			switch flag {
 			case ChIsFirstOfStr:
 				result = append(result, toAsciiLowerCase(ch))
@@ -125,12 +121,17 @@ func KebabCaseWithSep(input, seps string) string {
 				result = append(result, ch)
 			}
 			flag = ChIsOther
-		} else {
+		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
 			if flag == ChIsNextOfSepMark {
-				result = append(result, '-')
+				result = append(result, '-', ch)
+			} else {
+				result = append(result, ch)
 			}
-			result = append(result, ch)
 			flag = ChIsNextOfKeepedMark
+		} else {
+			if flag != ChIsFirstOfStr {
+				flag = ChIsNextOfSepMark
+			}
 		}
 	}
 

--- a/macro_case.go
+++ b/macro_case.go
@@ -95,11 +95,7 @@ func MacroCaseWithSep(input, seps string) string {
 	var flag uint8 = ChIsFirstOfStr
 
 	for _, ch := range input {
-		if strings.ContainsRune(seps, ch) {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		} else if isAsciiUpperCase(ch) {
+		if isAsciiUpperCase(ch) {
 			switch flag {
 			case ChIsFirstOfStr:
 				result = append(result, ch)
@@ -124,13 +120,17 @@ func MacroCaseWithSep(input, seps string) string {
 				result = append(result, toAsciiUpperCase(ch))
 			}
 			flag = ChIsOther
-		} else {
+		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
 			if flag == ChIsNextOfSepMark {
 				result = append(result, '_', ch)
 			} else {
 				result = append(result, ch)
 			}
 			flag = ChIsNextOfKeepedMark
+		} else {
+			if flag != ChIsFirstOfStr {
+				flag = ChIsNextOfSepMark
+			}
 		}
 	}
 

--- a/pascal_case.go
+++ b/pascal_case.go
@@ -88,11 +88,7 @@ func PascalCaseWithSep(input, seps string) string {
 	var flag uint8 = ChIsFirstOfStr
 
 	for _, ch := range input {
-		if strings.ContainsRune(seps, ch) {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfMark
-			}
-		} else if isAsciiUpperCase(ch) {
+		if isAsciiUpperCase(ch) {
 			switch flag {
 			case ChIsNextOfUpper:
 				result = append(result, toAsciiLowerCase(ch))
@@ -118,9 +114,13 @@ func PascalCaseWithSep(input, seps string) string {
 				result = append(result, ch)
 				flag = ChIsOther
 			}
-		} else {
+		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
 			result = append(result, ch)
 			flag = ChIsNextOfMark
+		} else {
+			if flag != ChIsFirstOfStr {
+				flag = ChIsNextOfMark
+			}
 		}
 	}
 

--- a/snake_case.go
+++ b/snake_case.go
@@ -95,11 +95,7 @@ func SnakeCaseWithSep(input, seps string) string {
 	var flag uint8 = ChIsFirstOfStr
 
 	for _, ch := range input {
-		if strings.ContainsRune(seps, ch) {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		} else if isAsciiUpperCase(ch) {
+		if isAsciiUpperCase(ch) {
 			switch flag {
 			case ChIsFirstOfStr:
 				result = append(result, toAsciiLowerCase(ch))
@@ -124,13 +120,17 @@ func SnakeCaseWithSep(input, seps string) string {
 				result = append(result, ch)
 			}
 			flag = ChIsOther
-		} else {
+		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
 			if flag == ChIsNextOfSepMark {
 				result = append(result, '_', ch)
 			} else {
 				result = append(result, ch)
 			}
 			flag = ChIsNextOfKeepedMark
+		} else {
+			if flag != ChIsFirstOfStr {
+				flag = ChIsNextOfSepMark
+			}
 		}
 	}
 

--- a/train_case.go
+++ b/train_case.go
@@ -101,11 +101,7 @@ func TrainCaseWithSep(input, seps string) string {
 	var flag uint8 = ChIsFirstOfStr
 
 	for _, ch := range input {
-		if strings.ContainsRune(seps, ch) {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		} else if isAsciiUpperCase(ch) {
+		if isAsciiUpperCase(ch) {
 			switch flag {
 			case ChIsFirstOfStr:
 				result = append(result, ch)
@@ -135,13 +131,17 @@ func TrainCaseWithSep(input, seps string) string {
 				result = append(result, ch)
 			}
 			flag = ChIsOther
-		} else {
+		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
 			if flag == ChIsNextOfSepMark {
 				result = append(result, '-', ch)
 			} else {
 				result = append(result, ch)
 			}
 			flag = ChIsNextOfKeepedMark
+		} else {
+			if flag != ChIsFirstOfStr {
+				flag = ChIsNextOfSepMark
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR modifies the behaviors of `*_case_with_seps` functions to ignore alphabets or digits in the second argument `seps`.

These modifications are expected to slightly impact performance as well.