### PR TITLE
new!: added SnakeCaseWithOptions, updated SnakeCase to use it, and deprecated SnakeCaseWithSep/Keep.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/sttk/stringcase"
 )
 
+// camel case
+
 func BenchmarkCamelCase(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		stringcase.CamelCase("foo-bar100%baz")
@@ -23,6 +25,8 @@ func BenchmarkCamelCaseWithKeep(b *testing.B) {
 		stringcase.CamelCaseWithSep("foo-bar100%baz", "%")
 	}
 }
+
+// cobol case
 
 func BenchmarkCobolCase(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -42,6 +46,8 @@ func BenchmarkCobolCaseWithKeep(b *testing.B) {
 	}
 }
 
+// kebab case
+
 func BenchmarkKebabCase(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		stringcase.KebabCase("foo-bar100%baz")
@@ -59,6 +65,8 @@ func BenchmarkKebabCaseWithKeep(b *testing.B) {
 		stringcase.KebabCaseWithKeep("foo-bar100%baz", "%")
 	}
 }
+
+// macro case
 
 func BenchmarkMacroCase(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -78,6 +86,8 @@ func BenchmarkMacroCaseWithKeep(b *testing.B) {
 	}
 }
 
+// pascal case
+
 func BenchmarkPascalCase(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		stringcase.PascalCase("foo-bar100%baz")
@@ -96,23 +106,153 @@ func BenchmarkPascalCaseWithKeep(b *testing.B) {
 	}
 }
 
+// snake case
+
 func BenchmarkSnakeCase(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		stringcase.SnakeCase("foo-bar100%baz")
 	}
 }
-
-func BenchmarkSnakeCaseWithSep(b *testing.B) {
+func BenchmarkSnakeCase_nonAlphabetsAsHead(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+	}
 	for i := 0; i < b.N; i++ {
-		stringcase.SnakeCaseWithSep("foo-bar100%baz", "-")
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsTail(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsWord(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsPart(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
 	}
 }
 
-func BenchmarkSnakeCaseWithKeep(b *testing.B) {
+func BenchmarkSnakeCase_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
 	for i := 0; i < b.N; i++ {
-		stringcase.SnakeCaseWithKeep("foo-bar100%baz", "%")
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
 	}
 }
+func BenchmarkSnakeCase_nonAlphabetsAsHead_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsTail_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsWord_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsPart_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
+func BenchmarkSnakeCase_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsHead_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsTail_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsWord_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkSnakeCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
+// train case
 
 func BenchmarkTrainCase(b *testing.B) {
 	for i := 0; i < b.N; i++ {

--- a/example_snake_case_test.go
+++ b/example_snake_case_test.go
@@ -8,9 +8,78 @@ import (
 
 func ExampleSnakeCase() {
 	snake := stringcase.SnakeCase("fooBarBaz")
-	fmt.Printf("snake = %s\n", snake)
+	fmt.Printf("(1) snake = %s\n", snake)
+
+	snake = stringcase.SnakeCase("foo-Bar100baz")
+	fmt.Printf("(2) snake = %s\n", snake)
 	// Output:
-	// snake = foo_bar_baz
+	// (1) snake = foo_bar_baz
+	// (2) snake = foo_bar100_baz
+}
+
+func ExampleSnakeCaseWithOptions() {
+	opts := stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true}
+	snake := stringcase.SnakeCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(1) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(2) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(3) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(4) snake = %s\n\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Separators: "#"}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(5) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Separators: "#"}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(6) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Separators: "#"}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(7) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Separators: "#"}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(8) snake = %s\n\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Keep: "%"}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(9) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Keep: "%"}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(a) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Keep: "%"}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(b) snake = %s\n", snake)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Keep: "%"}
+	snake = stringcase.SnakeCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(c) snake = %s\n", snake)
+	// Output:
+	// (1) snake = foo_bar100_baz
+	// (2) snake = foo_bar_100_baz
+	// (3) snake = foo_bar_100baz
+	// (4) snake = foo_bar100baz
+	//
+	// (5) snake = foo_bar100%_baz
+	// (6) snake = foo_bar_100%_baz
+	// (7) snake = foo_bar_100%baz
+	// (8) snake = foo_bar100%baz
+	//
+	// (9) snake = foo_bar100%_baz
+	// (a) snake = foo_bar_100%_baz
+	// (b) snake = foo_bar_100%baz
+	// (c) snake = foo_bar100%baz
 }
 
 func ExampleSnakeCaseWithSep() {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package stringcase
+
+// Options is a struct that represents options for case conversion of strings.
+//
+// The SeparateBeforeNonAlphabets field specifies whether to treat the
+// beginning of a sequence of non-alphabetical characters as a word
+// boundary. The SeparateAfterNonAlphabets field specifies whether to
+// treat the end of a sequence of non-alphabetical characters as a word
+// boundary. The Separators field specifies the set of characters to be
+// treated as word separators and removed from the result string. The
+// Keep field specifies the set of characters not to be treated as word
+// separators wnd kept in the result string.
+//
+// Alphanumeric characters specified in Separators and Keep are ignored.
+// If both Separators and Keep are specified, Separators takes precedence
+// and Keep is ignored.
+type Options struct {
+	SeparateBeforeNonAlphabets bool
+	SeparateAfterNonAlphabets  bool
+	Separators                 string
+	Keep                       string
+}

--- a/snake_case.go
+++ b/snake_case.go
@@ -8,196 +8,120 @@ import (
 	"strings"
 )
 
-// Converts a string to snake case.
+// SnakeCaseWithOptions converts the input string to snake case with the
+// specified options.
+func SnakeCaseWithOptions(input string, opts Options) string {
+	result := make([]rune, 0, len(input)+len(input)/2)
+
+	const (
+		ChIsFirstOfStr = iota
+		ChIsNextOfUpper
+		ChIsNextOfContdUpper
+		ChIsNextOfSepMark
+		ChIsNextOfKeptMark
+		ChIsOther
+	)
+	var flag uint8 = ChIsFirstOfStr
+
+	for _, ch := range input {
+		if isAsciiUpperCase(ch) {
+			if flag == ChIsFirstOfStr {
+				result = append(result, toAsciiLowerCase(ch))
+				flag = ChIsNextOfUpper
+			} else if flag == ChIsNextOfUpper || flag == ChIsNextOfContdUpper ||
+				(!opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, toAsciiLowerCase(ch))
+				flag = ChIsNextOfContdUpper
+			} else {
+				result = append(result, '_', toAsciiLowerCase(ch))
+				flag = ChIsNextOfUpper
+			}
+		} else if isAsciiLowerCase(ch) {
+			if flag == ChIsNextOfContdUpper {
+				n := len(result)
+				prev := result[n-1]
+				result[n-1] = '_'
+				result = append(result, prev, ch)
+			} else if flag == ChIsNextOfSepMark ||
+				(opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, '_', ch)
+			} else {
+				result = append(result, ch)
+			}
+			flag = ChIsOther
+		} else {
+			isKeptChar := false
+			if len(opts.Separators) > 0 {
+				if !strings.ContainsRune(opts.Separators, ch) {
+					isKeptChar = true
+				}
+			} else if len(opts.Keep) > 0 {
+				if isAsciiDigit(ch) || strings.ContainsRune(opts.Keep, ch) {
+					isKeptChar = true
+				}
+			} else {
+				if isAsciiDigit(ch) {
+					isKeptChar = true
+				}
+			}
+
+			if isKeptChar {
+				if opts.SeparateBeforeNonAlphabets {
+					if flag == ChIsFirstOfStr || flag == ChIsNextOfKeptMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '_', ch)
+					}
+				} else {
+					if flag != ChIsNextOfSepMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '_', ch)
+					}
+				}
+				flag = ChIsNextOfKeptMark
+			} else {
+				if flag != ChIsFirstOfStr {
+					flag = ChIsNextOfSepMark
+				}
+			}
+		}
+	}
+
+	return string(result)
+}
+
+// SnakeCase converts the input string to snake case.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is snake case.
-//
-// This function targets the upper and lower cases of ASCII alphabets for
-// capitalization, and all characters except ASCII alphabets and ASCII numbers
-// are eliminated as word separators.
+// It treats the end of a sequence of non-alphabetical characters as a
+// word boundary, but not the beginning.
 func SnakeCase(input string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '_', toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '_'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '_', ch)
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '_', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+	return SnakeCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	})
 }
 
-// Converts a string to snake case using the specified characters as
-// separators.
+// SnakeCaseWithSep converts the input string to snake case with the
+// specified separator characters.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is snake case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters specified as the second argument of this
-// function are regarded as word separators and are replaced to underscores.
-func SnakeCaseWithSep(input, seps string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '_', toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '_'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '_', ch)
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '_', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use StringCaseWithOptions instead
+func SnakeCaseWithSep(input string, seps string) string {
+	return SnakeCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 seps,
+	})
 }
 
-// Converts a string to snake case using characters other than the specified
-// characters as separators.
+// SnakeCaseWithKeep converts the input string to snake case with the
+// specified characters to be kept.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is snake case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters other than the specified characters as the
-// second argument of this function are regarded as word separators and are
-// replaced to underscores.
-func SnakeCaseWithKeep(input, keeped string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '_', toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '_'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '_', ch)
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || strings.ContainsRune(keeped, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '_')
-			}
-			flag = ChIsNextOfKeepedMark
-			result = append(result, ch)
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use StringCaseWithOptions instead
+func SnakeCaseWithKeep(input string, kept string) string {
+	return SnakeCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       kept,
+	})
 }

--- a/snake_case_test.go
+++ b/snake_case_test.go
@@ -8,216 +8,1229 @@ import (
 	"github.com/sttk/stringcase"
 )
 
-func TestSnakeCase_convertCamelCase(t *testing.T) {
-	result := stringcase.SnakeCase("abcDefGHIjk")
-	assert.Equal(t, result, "abc_def_gh_ijk")
+func TestSnakeCase(t *testing.T) {
+	t.Run("convert camelCase", func(t *testing.T) {
+		result := stringcase.SnakeCase("abcDefGHIjk")
+		assert.Equal(t, result, "abc_def_gh_ijk")
+	})
+
+	t.Run("convert PascalCase", func(t *testing.T) {
+		result := stringcase.SnakeCase("AbcDefGHIjk")
+		assert.Equal(t, result, "abc_def_gh_ijk")
+	})
+
+	t.Run("convert snake_case", func(t *testing.T) {
+		result := stringcase.SnakeCase("abc_def_ghi")
+		assert.Equal(t, result, "abc_def_ghi")
+	})
+
+	t.Run("convert kebab-case", func(t *testing.T) {
+		result := stringcase.SnakeCase("abc-def-ghi")
+		assert.Equal(t, result, "abc_def_ghi")
+	})
+
+	t.Run("convert Trail-Case", func(t *testing.T) {
+		result := stringcase.SnakeCase("Abc-Def-Ghi")
+		assert.Equal(t, result, "abc_def_ghi")
+	})
+
+	t.Run("convert MACRO_CASE", func(t *testing.T) {
+		result := stringcase.SnakeCase("ABC_DEF_GHI")
+		assert.Equal(t, result, "abc_def_ghi")
+	})
+
+	t.Run("convert COBOL-CASE", func(t *testing.T) {
+		result := stringcase.SnakeCase("ABC-DEF-GHI")
+		assert.Equal(t, result, "abc_def_ghi")
+	})
+
+	t.Run("convert with keeping digits", func(t *testing.T) {
+		result := stringcase.SnakeCase("abc123-456defG89HIJklMN12")
+		assert.Equal(t, result, "abc123_456_def_g89_hi_jkl_mn12")
+	})
+
+	t.Run("convert with symbols as seperators", func(t *testing.T) {
+		result := stringcase.SnakeCase(":.abc~!@def#$ghi%&jk(lm)no/?")
+		assert.Equal(t, result, "abc_def_ghi_jk_lm_no")
+	})
+
+	t.Run("convert when starting with digit", func(t *testing.T) {
+		result := stringcase.SnakeCase("123abc456def")
+		assert.Equal(t, result, "123_abc456_def")
+
+		result = stringcase.SnakeCase("123ABC456DEF")
+		assert.Equal(t, result, "123_abc456_def")
+
+		result = stringcase.SnakeCase("123Abc456Def")
+		assert.Equal(t, result, "123_abc456_def")
+	})
+
+	t.Run("convert an empty string", func(t *testing.T) {
+		result := stringcase.SnakeCase("")
+		assert.Equal(t, result, "")
+	})
 }
 
-func TestSnakeCase_convertPascalCase(t *testing.T) {
-	result := stringcase.SnakeCase("AbcDefGHIjk")
-	assert.Equal(t, result, "abc_def_gh_ijk")
-}
+func TestSnakeCaseWithOptions(t *testing.T) {
+	t.Run("non-alphabets as head of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestSnakeCase_convertSnakeCase(t *testing.T) {
-	result := stringcase.SnakeCase("abc_def_ghi")
-	assert.Equal(t, result, "abc_def_ghi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
 
-func TestSnakeCase_convertKebabCase(t *testing.T) {
-	result := stringcase.SnakeCase("abc-def-ghi")
-	assert.Equal(t, result, "abc_def_ghi")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
 
-func TestSnakeCase_convertTrainCase(t *testing.T) {
-	result := stringcase.SnakeCase("Abc-Def-Ghi")
-	assert.Equal(t, result, "abc_def_ghi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCase_convertMacroCase(t *testing.T) {
-	result := stringcase.SnakeCase("ABC_DEF_GHI")
-	assert.Equal(t, result, "abc_def_ghi")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCase_convertCobolCase(t *testing.T) {
-	result := stringcase.SnakeCase("ABC-DEF-GHI")
-	assert.Equal(t, result, "abc_def_ghi")
-}
+		t.Run("convert Trail-Case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCase_convertKeepDigits(t *testing.T) {
-	result := stringcase.SnakeCase("abc123-456defG89HIJklMN12")
-	assert.Equal(t, result, "abc123_456_def_g89_hi_jkl_mn12")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCase_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.SnakeCase(":.abc~!@def#$ghi%&jk(lm)no/?")
-	assert.Equal(t, result, "abc_def_ghi_jk_lm_no")
-}
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCase_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.SnakeCase("123abc456def")
-	assert.Equal(t, result, "123_abc456_def")
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123_456def_g_89hi_jkl_mn_12")
+		})
 
-	result = stringcase.SnakeCase("123ABC456DEF")
-	assert.Equal(t, result, "123_abc456_def")
-}
+		t.Run("convert with symbols as seperators", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abc_def_ghi_jk_lm_no")
+		})
 
-func TestSnakeCase_convertEmpty(t *testing.T) {
-	result := stringcase.SnakeCase("")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc_456def")
 
-///
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc_456def")
 
-func TestSnakeCaseWithSep_convertCamelCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "abc_def_gh_ijk")
-}
+			result = stringcase.SnakeCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_abc_456_def")
+		})
 
-func TestSnakeCaseWithSep_convertPascalCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "abc_def_gh_ijk")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestSnakeCaseWithSep_convertSnakeCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("abc_def_ghi", "_")
-	assert.Equal(t, result, "abc_def_ghi")
+	t.Run("non-alphabets as tail of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-	result = stringcase.SnakeCaseWithSep("abc_def_ghi", "-")
-	assert.Equal(t, result, "abc__def__ghi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
 
-func TestSnakeCaseWithSep_convertKebabCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("abc-def-ghi", "-")
-	assert.Equal(t, result, "abc_def_ghi")
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
 
-	result = stringcase.SnakeCaseWithSep("abc-def-ghi", "_")
-	assert.Equal(t, result, "abc-_def-_ghi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCaseWithSep_convertTrainCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "abc_def_ghi")
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-	result = stringcase.SnakeCaseWithSep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "abc-_def-_ghi")
-}
+		t.Run("convert Trail-Case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCaseWithSep_convertMacroCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "abc_def_ghi")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-	result = stringcase.SnakeCaseWithSep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "abc__def__ghi")
-}
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCaseWithSep_convertCobolCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "abc_def_ghi")
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123_456_def_g89_hi_jkl_mn12")
+		})
 
-	result = stringcase.SnakeCaseWithSep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "abc-_def-_ghi")
-}
+		t.Run("convert with symbols as seperators", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abc_def_ghi_jk_lm_no")
+		})
 
-func TestSnakeCaseWithSep_keepDigits(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("abc123-456defG89HIJklMN12", "-")
-	assert.Equal(t, result, "abc123_456_def_g89_hi_jkl_mn12")
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_abc456_def")
 
-	result = stringcase.SnakeCaseWithSep("abc123-456defG89HIJklMN12", "_")
-	assert.Equal(t, result, "abc123-456_def_g89_hi_jkl_mn12")
-}
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_abc456_def")
 
-func TestSnakeCaseWithSep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("123abc456def", "-")
-	assert.Equal(t, result, "123_abc456_def")
+			result = stringcase.SnakeCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_abc456_def")
+		})
 
-	result = stringcase.SnakeCaseWithSep("123ABC456DEF", "-")
-	assert.Equal(t, result, "123_abc456_def")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestSnakeCaseWithSep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/")
-	assert.Equal(t, result, "._abc~!_def#_ghi%_jk_lm_no_?")
-}
+	t.Run("non-alphabets as a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-func TestSnakeCaseWithSep_convertEmpty(t *testing.T) {
-	result := stringcase.SnakeCaseWithSep("", "-_")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
 
-///
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
 
-func TestSnakeCaseWithKeep_convertCamelCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "abc_def_gh_ijk")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCaseWithKeep_convertPascalCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "abc_def_gh_ijk")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCaseWithKeep_convertSnakeCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("abc_def_ghi", "-")
-	assert.Equal(t, result, "abc_def_ghi")
+		t.Run("convert Trail-Case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-	result = stringcase.SnakeCaseWithKeep("abc_def_ghi", "_")
-	assert.Equal(t, result, "abc__def__ghi")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCaseWithKeep_convertKebabCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("abc-def-ghi", "_")
-	assert.Equal(t, result, "abc_def_ghi")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-	result = stringcase.SnakeCaseWithKeep("abc-def-ghi", "-")
-	assert.Equal(t, result, "abc-_def-_ghi")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123_456_def_g_89_hi_jkl_mn_12")
+		})
 
-func TestSnakeCaseWithKeep_convertTrainCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "abc_def_ghi")
+		t.Run("convert with symbols as seperators", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abc_def_ghi_jk_lm_no")
+		})
 
-	result = stringcase.SnakeCaseWithKeep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "abc-_def-_ghi")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_abc_456_def")
 
-func TestSnakeCaseWithKeep_convertMacroCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "abc_def_ghi")
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_abc_456_def")
 
-	result = stringcase.SnakeCaseWithKeep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "abc__def__ghi")
-}
+			result = stringcase.SnakeCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_abc_456_def")
+		})
 
-func TestSnakeCaseWithKeep_convertCobolCase(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "abc_def_ghi")
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-	result = stringcase.SnakeCaseWithKeep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "abc-_def-_ghi")
-}
+	t.Run("non-alphabets as part of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestSnakeCaseWithKeep_keepDigits(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("abc123-456defG89HIJklMN12", "_")
-	assert.Equal(t, result, "abc123_456_def_g89_hi_jkl_mn12")
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
 
-	result = stringcase.SnakeCaseWithKeep("abc123-456defG89HIJklMN12", "-")
-	assert.Equal(t, result, "abc123-456_def_g89_hi_jkl_mn12")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
 
-func TestSnakeCaseWithKeep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("123abc456def", "-")
-	assert.Equal(t, result, "123_abc456_def")
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-	result = stringcase.SnakeCaseWithKeep("123ABC456DEF", "-")
-	assert.Equal(t, result, "123_abc456_def")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCaseWithKeep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?")
-	assert.Equal(t, result, "._abc~!_def#_ghi%_jk_lm_no_?")
-}
+		t.Run("convert Trail-Case", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
 
-func TestSnakeCaseWithKeep_convertEmpty(t *testing.T) {
-	result := stringcase.SnakeCaseWithKeep("", "-_")
-	assert.Equal(t, result, "")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123_456def_g89hi_jkl_mn12")
+		})
+
+		t.Run("convert with symbols as seperators", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abc_def_ghi_jk_lm_no")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.SnakeCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_abc456_def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "-"
+			result = stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc__def__ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "-"
+			result = stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc__def__ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123_456def_g_89hi_jkl_mn_12")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123-456def_g_89hi_jkl_mn_12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc_~!_def_#_ghi_%_jk_lm_no_?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc_456def")
+
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc_456def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "-"
+			result = stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc__def__ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "-"
+			result = stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc__def__ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123_456_def_g89_hi_jkl_mn12")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456_def_g89_hi_jkl_mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "._abc~!_def#_ghi%_jk_lm_no_?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_abc456_def")
+
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_abc456_def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "-"
+			result = stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc___def___ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "-"
+			result = stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc___def___ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123_456_def_g_89_hi_jkl_mn_12")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123-456_def_g_89_hi_jkl_mn_12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "._abc_~!_def_#_ghi_%_jk_lm_no_?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_abc_456_def")
+
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_abc_456_def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "-"
+			result = stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "-"
+			result = stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123_456def_g89hi_jkl_mn12")
+
+			opts.Separators = "_"
+			result = stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def_g89hi_jkl_mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!_def#_ghi%_jk_lm_no_?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc__def__ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc__def__ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123_456def_g_89hi_jkl_mn_12")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123-456def_g_89hi_jkl_mn_12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc_456def")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc_456def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc_~!_def_#_ghi_%_jk_lm_no_?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc__def__ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc__def__ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123_456_def_g89_hi_jkl_mn12")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456_def_g89_hi_jkl_mn12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_abc456_def")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_abc456_def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "._abc~!_def#_ghi%_jk_lm_no_?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc___def___ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc___def___ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123_456_def_g_89_hi_jkl_mn_12")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc_123-456_def_g_89_hi_jkl_mn_12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_abc_456_def")
+
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_abc_456_def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "._abc_~!_def_#_ghi_%_jk_lm_no_?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc_def_gh_ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "_"
+			result = stringcase.SnakeCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123_456def_g89hi_jkl_mn12")
+
+			opts.Keep = "-"
+			result = stringcase.SnakeCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def_g89hi_jkl_mn12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.SnakeCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.SnakeCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.SnakeCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!_def#_ghi%_jk_lm_no_?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.SnakeCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 }


### PR DESCRIPTION
(Related #5)

This PR adds the new function `SnakeCaseWithOptions`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`SnakeCase` is changed to use this function inside, and both `SnakeCaseWithSep` and `SnakeCaseWithKeep` are deprecated.
