### PR TITLE
new!: added TrainCaseWithOptions, updated existing TrainCase* to use it

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -113,6 +113,62 @@ func BenchmarkSnakeCase(b *testing.B) {
 		stringcase.SnakeCase("foo-bar100%baz")
 	}
 }
+
+func BenchmarkSnakeCase_withSep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
+func BenchmarkSnakeCase_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
+// train case
+
+func BenchmarkTrainCase(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCase("foo-bar100%baz")
+	}
+}
+
+func BenchmarkTrainCase_withSep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
+func BenchmarkTrainCase_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
+
+// snake case with options
+
 func BenchmarkSnakeCase_nonAlphabetsAsHead(b *testing.B) {
 	opts := stringcase.Options{
 		SeparateBeforeNonAlphabets: true,
@@ -144,17 +200,6 @@ func BenchmarkSnakeCase_nonAlphabetsAsPart(b *testing.B) {
 	opts := stringcase.Options{
 		SeparateBeforeNonAlphabets: false,
 		SeparateAfterNonAlphabets:  false,
-	}
-	for i := 0; i < b.N; i++ {
-		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
-	}
-}
-
-func BenchmarkSnakeCase_withSeparators(b *testing.B) {
-	opts := stringcase.Options{
-		SeparateBeforeNonAlphabets: false,
-		SeparateAfterNonAlphabets:  true,
-		Separators:                 "-",
 	}
 	for i := 0; i < b.N; i++ {
 		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
@@ -195,17 +240,6 @@ func BenchmarkSnakeCase_nonAlphabetsAsPart_withSeparators(b *testing.B) {
 		SeparateBeforeNonAlphabets: false,
 		SeparateAfterNonAlphabets:  false,
 		Separators:                 "-",
-	}
-	for i := 0; i < b.N; i++ {
-		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
-	}
-}
-
-func BenchmarkSnakeCase_withKeep(b *testing.B) {
-	opts := stringcase.Options{
-		SeparateBeforeNonAlphabets: false,
-		SeparateAfterNonAlphabets:  true,
-		Keep:                       "%",
 	}
 	for i := 0; i < b.N; i++ {
 		stringcase.SnakeCaseWithOptions("foo-bar100%baz", opts)
@@ -252,22 +286,121 @@ func BenchmarkSnakeCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
 	}
 }
 
-// train case
+// train case with options
 
-func BenchmarkTrainCase(b *testing.B) {
+func BenchmarkTrainCase_nonAlphabetsAsHead(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+	}
 	for i := 0; i < b.N; i++ {
-		stringcase.TrainCase("foo-bar100%baz")
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
 	}
 }
-
-func BenchmarkTrainCaseWithSep(b *testing.B) {
+func BenchmarkTrainCase_nonAlphabetsAsTail(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	}
 	for i := 0; i < b.N; i++ {
-		stringcase.TrainCaseWithSep("foo-bar100%baz", "-")
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
 	}
 }
-
-func BenchmarkTrainCaseWithKeep(b *testing.B) {
+func BenchmarkTrainCase_nonAlphabetsAsWord(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+	}
 	for i := 0; i < b.N; i++ {
-		stringcase.TrainCaseWithKeep("foo-bar100%baz", "%")
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsPart(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsHead_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsTail_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsWord_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsPart_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsHead_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsTail_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsWord_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkTrainCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.TrainCaseWithOptions("foo-bar100%baz", opts)
 	}
 }

--- a/example_train_case_test.go
+++ b/example_train_case_test.go
@@ -8,9 +8,78 @@ import (
 
 func ExampleTrainCase() {
 	train := stringcase.TrainCase("fooBarBaz")
-	fmt.Printf("train = %s\n", train)
+	fmt.Printf("(1) train = %s\n", train)
+
+	train = stringcase.TrainCase("foo-Bar100baz")
+	fmt.Printf("(2) train = %s\n", train)
 	// Output:
-	// train = Foo-Bar-Baz
+	// (1) train = Foo-Bar-Baz
+	// (2) train = Foo-Bar100-Baz
+}
+
+func ExampleTrainCaseWithOptions() {
+	opts := stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true}
+	train := stringcase.TrainCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(1) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(2) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(3) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(4) train = %s\n\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Separators: "#"}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(5) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Separators: "#"}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(6) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Separators: "#"}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(7) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Separators: "#"}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(8) train = %s\n\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Keep: "%"}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(9) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Keep: "%"}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(a) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Keep: "%"}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(b) train = %s\n", train)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Keep: "%"}
+	train = stringcase.TrainCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(c) train = %s\n", train)
+	// Output:
+	// (1) train = Foo-Bar100-Baz
+	// (2) train = Foo-Bar-100-Baz
+	// (3) train = Foo-Bar-100baz
+	// (4) train = Foo-Bar100baz
+	//
+	// (5) train = Foo-Bar100%-Baz
+	// (6) train = Foo-Bar-100%-Baz
+	// (7) train = Foo-Bar-100%baz
+	// (8) train = Foo-Bar100%baz
+	//
+	// (9) train = Foo-Bar100%-Baz
+	// (a) train = Foo-Bar-100%-Baz
+	// (b) train = Foo-Bar-100%baz
+	// (c) train = Foo-Bar100%baz
 }
 
 func ExampleTrainCaseWithSep() {

--- a/train_case.go
+++ b/train_case.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
@@ -8,213 +8,121 @@ import (
 	"strings"
 )
 
-// Converts a string to train case.
+// TrainCaseWithOptions converts the input string to train case with the
+// specified options.
+func TrainCaseWithOptions(input string, opts Options) string {
+	result := make([]rune, 0, len(input)+len(input)/2)
+
+	const (
+		ChIsFirstOfStr = iota
+		ChIsNextOfUpper
+		ChIsNextOfContdUpper
+		ChIsNextOfSepMark
+		ChIsNextOfKeptMark
+		ChIsOther
+	)
+	var flag uint8 = ChIsFirstOfStr
+
+	for _, ch := range input {
+		if isAsciiUpperCase(ch) {
+			if flag == ChIsFirstOfStr {
+				result = append(result, ch)
+				flag = ChIsNextOfUpper
+			} else if flag == ChIsNextOfUpper || flag == ChIsNextOfContdUpper ||
+				(!opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, toAsciiLowerCase(ch))
+				flag = ChIsNextOfContdUpper
+			} else {
+				result = append(result, '-', ch)
+				flag = ChIsNextOfUpper
+			}
+		} else if isAsciiLowerCase(ch) {
+			if flag == ChIsFirstOfStr {
+				result = append(result, toAsciiUpperCase(ch))
+			} else if flag == ChIsNextOfContdUpper {
+				n := len(result)
+				prev := result[n-1]
+				if isAsciiLowerCase(prev) {
+					prev = toAsciiUpperCase(prev)
+				}
+				result[n-1] = '-'
+				result = append(result, prev, ch)
+			} else if flag == ChIsNextOfSepMark ||
+				(opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, '-', toAsciiUpperCase(ch))
+			} else {
+				result = append(result, ch)
+			}
+			flag = ChIsOther
+		} else {
+			isKeptChar := false
+			if len(opts.Separators) > 0 {
+				if !strings.ContainsRune(opts.Separators, ch) {
+					isKeptChar = true
+				}
+			} else if len(opts.Keep) > 0 {
+				if isAsciiDigit(ch) || strings.ContainsRune(opts.Keep, ch) {
+					isKeptChar = true
+				}
+			} else {
+				if isAsciiDigit(ch) {
+					isKeptChar = true
+				}
+			}
+
+			if isKeptChar {
+				if opts.SeparateBeforeNonAlphabets {
+					if flag == ChIsFirstOfStr || flag == ChIsNextOfKeptMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '-', ch)
+					}
+				} else {
+					if flag != ChIsNextOfSepMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '-', ch)
+					}
+				}
+				flag = ChIsNextOfKeptMark
+			} else {
+				if flag != ChIsFirstOfStr {
+					flag = ChIsNextOfSepMark
+				}
+			}
+		}
+	}
+
+	return string(result)
+}
+
+// TrainCase converts the input string to train case.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is train case.
-//
-// This function targets the upper and lower cases of ASCII alphabets for
-// capitalization, and all characters except ASCII alphabets and ASCII numbers
-// are eliminated as word separators.
+// It treats the end of a sequence of non-alphabetical characters as a
+// word boundary, but not the beginning.
 func TrainCase(input string) string {
-	result := make([]rune, 0, len(input)*2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-', ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiUpperCase(ch))
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				if isAsciiLowerCase(prev) {
-					prev = toAsciiUpperCase(prev)
-				}
-				result[n-1] = '-'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-', toAsciiUpperCase(ch))
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) {
-			switch flag {
-			case ChIsNextOfSepMark:
-				result = append(result, '-', ch)
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+	return TrainCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	})
 }
 
-// Converts a string to train case using the specified characters as
-// separators.
-//
-// This function takes a string as its argument, then returns a string of which
-// the case style is train case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters specified as the second argument of this
-// function are regarded as word separators and are replaced to hyphens.
-func TrainCaseWithSep(input, seps string) string {
-	result := make([]rune, 0, len(input)*2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-', ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiUpperCase(ch))
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				if isAsciiLowerCase(prev) {
-					prev = toAsciiUpperCase(prev)
-				}
-				result[n-1] = '-'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-', toAsciiUpperCase(ch))
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '-', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// TrainCaseWithSep converts the input string to train case with the
+// specified separator characters.
+func TrainCaseWithSep(input string, seps string) string {
+	return TrainCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 seps,
+	})
 }
 
-// Converts a string to train case using characters other than the specified
-// characters as separators.
-//
-// This function takes a string as its argument, then returns a string of which
-// the case style is train case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters other than the specified characters as
-// the second argument of this function are regarded as word separators and
-// are replaced to hyphens.
-func TrainCaseWithKeep(input, keeped string) string {
-	result := make([]rune, 0, len(input)*2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-', ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiUpperCase(ch))
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				if isAsciiLowerCase(prev) {
-					prev = toAsciiUpperCase(prev)
-				}
-				result[n-1] = '-'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-', toAsciiUpperCase(ch))
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || strings.ContainsRune(keeped, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '-', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// TrainCaseWithKeep converts the input string to train case with the
+// specified characters to be kept.
+func TrainCaseWithKeep(input string, kept string) string {
+	return TrainCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       kept,
+	})
 }

--- a/train_case_test.go
+++ b/train_case_test.go
@@ -8,216 +8,1253 @@ import (
 	"github.com/sttk/stringcase"
 )
 
-func TestTrainCase_convertCamelCase(t *testing.T) {
-	result := stringcase.TrainCase("abcDefGHIjk")
-	assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+func TestTrainCase(t *testing.T) {
+	t.Run("convert camelCase", func(t *testing.T) {
+		result := stringcase.TrainCase("abcDefGHIjk")
+		assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+	})
+
+	t.Run("convert PascalCase", func(t *testing.T) {
+		result := stringcase.TrainCase("AbcDefGHIjk")
+		assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+	})
+
+	t.Run("convert snake_case", func(t *testing.T) {
+		result := stringcase.TrainCase("abc_def_ghi")
+		assert.Equal(t, result, "Abc-Def-Ghi")
+	})
+
+	t.Run("convert kebab-case", func(t *testing.T) {
+		result := stringcase.TrainCase("abc-def-ghi")
+		assert.Equal(t, result, "Abc-Def-Ghi")
+	})
+
+	t.Run("convert Train-Case", func(t *testing.T) {
+		result := stringcase.TrainCase("Abc-Def-Ghi")
+		assert.Equal(t, result, "Abc-Def-Ghi")
+	})
+
+	t.Run("convert MACRO_CASE", func(t *testing.T) {
+		result := stringcase.TrainCase("ABC_DEF_GHI")
+		assert.Equal(t, result, "Abc-Def-Ghi")
+	})
+
+	t.Run("convert COBOL-CASE", func(t *testing.T) {
+		result := stringcase.TrainCase("ABC-DEF-GHI")
+		assert.Equal(t, result, "Abc-Def-Ghi")
+	})
+
+	t.Run("convert with keeping digits", func(t *testing.T) {
+		result := stringcase.TrainCase("abc123-456defG89HIJklMN12")
+		assert.Equal(t, result, "Abc123-456-Def-G89-Hi-Jkl-Mn12")
+	})
+
+	t.Run("convert with symbols as separators", func(t *testing.T) {
+		result := stringcase.TrainCase(":.abc~!@def#$ghi%&jk(lm)no/?")
+		assert.Equal(t, result, "Abc-Def-Ghi-Jk-Lm-No")
+	})
+
+	t.Run("convert when starting with digit", func(t *testing.T) {
+		result := stringcase.TrainCase("123abc456def")
+		assert.Equal(t, result, "123-Abc456-Def")
+
+		result = stringcase.TrainCase("123ABC456DEF")
+		assert.Equal(t, result, "123-Abc456-Def")
+
+		result = stringcase.TrainCase("123Abc456Def")
+		assert.Equal(t, result, "123-Abc456-Def")
+	})
+
+	t.Run("convert an empty string", func(t *testing.T) {
+		result := stringcase.TrainCase("")
+		assert.Equal(t, result, "")
+	})
 }
 
-func TestTrainCase_convertPascalCase(t *testing.T) {
-	result := stringcase.TrainCase("AbcDefGHIjk")
-	assert.Equal(t, result, "Abc-Def-Gh-Ijk")
-}
+func TestTrainCaseWithOptions(t *testing.T) {
+	t.Run("non-alphabets as head of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestTrainCase_convertSnakeCase(t *testing.T) {
-	result := stringcase.TrainCase("abc_def_ghi")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
 
-func TestTrainCase_convertKebabCase(t *testing.T) {
-	result := stringcase.TrainCase("abc-def-ghi")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
 
-func TestTrainCase_convertTrainCase(t *testing.T) {
-	result := stringcase.TrainCase("Abc-Def-Ghi")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCase_convertMacroCase(t *testing.T) {
-	result := stringcase.TrainCase("ABC_DEF_GHI")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCase_convertCobolCase(t *testing.T) {
-	result := stringcase.TrainCase("ABC-DEF-GHI")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCase_keepDigits(t *testing.T) {
-	result := stringcase.TrainCase("abc123-456defG89HIJklMN12")
-	assert.Equal(t, result, "Abc123-456-Def-G89-Hi-Jkl-Mn12")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCase_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.TrainCase("123abc456def")
-	assert.Equal(t, result, "123-Abc456-Def")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-	result = stringcase.TrainCase("123ABC456DEF")
-	assert.Equal(t, result, "123-Abc456-Def")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc-123-456def-G-89hi-Jkl-Mn-12")
+		})
 
-func TestTrainCase_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.TrainCase(":.abc~!@def#$ghi%&jk(lm)no/?")
-	assert.Equal(t, result, "Abc-Def-Ghi-Jk-Lm-No")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi-Jk-Lm-No")
+		})
 
-func TestTrainCase_convertEmpty(t *testing.T) {
-	result := stringcase.TrainCase("")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc-456def")
 
-///
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc-456def")
 
-func TestTrainCaseWithSep_convertCamelCase(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "Abc-Def-Gh-Ijk")
-}
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
+		})
 
-func TestTrainCaseWithSep_convertPascalCase(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "Abc-Def-Gh-Ijk")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestTrainCaseWithSep_convertSnakeCase(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("abc_def_ghi", "_")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+	t.Run("non-alphabets as tail of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-	result = stringcase.TrainCaseWithSep("abc_def_ghi", "-")
-	assert.Equal(t, result, "Abc_-Def_-Ghi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
 
-func TestTrainCaseWithSep_convertKebabCase(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("abc-def-ghi", "-")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
 
-	result = stringcase.TrainCaseWithSep("abc-def-ghi", "_")
-	assert.Equal(t, result, "Abc--Def--Ghi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCaseWithSep_convertTrainCase(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-	result = stringcase.TrainCaseWithSep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "Abc--Def--Ghi")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCaseWithSep_convertMacroCase(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-	result = stringcase.TrainCaseWithSep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "Abc_-Def_-Ghi")
-}
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCaseWithSep_convertCobolCase(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456-Def-G89-Hi-Jkl-Mn12")
+		})
 
-	result = stringcase.TrainCaseWithSep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "Abc--Def--Ghi")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi-Jk-Lm-No")
+		})
 
-func TestTrainCaseWithSep_keepDigits(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "Abc123-456-Def-G789-Hi-Jkl-Mn12")
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
 
-	result = stringcase.TrainCaseWithSep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "Abc123-456-Def-G789-Hi-Jkl-Mn12")
-}
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
 
-func TestTrainCaseWithSep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("123abc456def", "-")
-	assert.Equal(t, result, "123-Abc456-Def")
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+		})
 
-	result = stringcase.TrainCaseWithSep("123ABC456DEF", "-")
-	assert.Equal(t, result, "123-Abc456-Def")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestTrainCaseWithSep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.TrainCaseWithSep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/")
-	assert.Equal(t, result, ".-Abc~!-Def#-Ghi%-Jk-Lm-No-?")
-}
+	t.Run("non-alphabets as a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-func TestTrainCaseWithSep_convertEmpty(t *testing.T) {
-	result := stringcase.TrainCaseWithSep("", "-_")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
 
-///
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
 
-func TestTrainCaseWithKeep_convertCamelCase(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "Abc-Def-Gh-Ijk")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCaseWithKeep_convertPascalCase(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "Abc-Def-Gh-Ijk")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCaseWithKeep_convertSnakeCase(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("abc_def_ghi", "-")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-	result = stringcase.TrainCaseWithKeep("abc_def_ghi", "_")
-	assert.Equal(t, result, "Abc_-Def_-Ghi")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCaseWithKeep_convertKebabCase(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("abc-def-ghi", "_")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-	result = stringcase.TrainCaseWithKeep("abc-def-ghi", "-")
-	assert.Equal(t, result, "Abc--Def--Ghi")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc-123-456-Def-G-89-Hi-Jkl-Mn-12")
+		})
 
-func TestTrainCaseWithKeep_convertTrainCase(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi-Jk-Lm-No")
+		})
 
-	result = stringcase.TrainCaseWithKeep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "Abc--Def--Ghi")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
 
-func TestTrainCaseWithKeep_convertMacroCase(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
 
-	result = stringcase.TrainCaseWithKeep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "Abc_-Def_-Ghi")
-}
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
+		})
 
-func TestTrainCaseWithKeep_convertCobolCase(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "Abc-Def-Ghi")
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-	result = stringcase.TrainCaseWithKeep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "Abc--Def--Ghi")
-}
+	t.Run("non-alphabets as part of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestTrainCaseWithKeep_keepDigits(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "Abc123-456-Def-G789-Hi-Jkl-Mn12")
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
 
-	result = stringcase.TrainCaseWithKeep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "Abc123-456-Def-G789-Hi-Jkl-Mn12")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
 
-func TestTrainCaseWithKeep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("123abc456def", "-")
-	assert.Equal(t, result, "123-Abc456-Def")
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-	result = stringcase.TrainCaseWithKeep("123ABC456DEF", "-")
-	assert.Equal(t, result, "123-Abc456-Def")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCaseWithKeep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?")
-	assert.Equal(t, result, ".-Abc~!-Def#-Ghi%-Jk-Lm-No-?")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
 
-func TestTrainCaseWithKeep_convertEmpty(t *testing.T) {
-	result := stringcase.TrainCaseWithKeep("", "-_")
-	assert.Equal(t, result, "")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456def-G89hi-Jkl-Mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi-Jk-Lm-No")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "-"
+			result = stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-_def-_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc--def--ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc---Def---Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "-"
+			result = stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-_def-_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc-123-456def-G-89hi-Jkl-Mn-12")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc-123-456def-G-89hi-Jkl-Mn-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc-~!-Def-#-Ghi-%-Jk-Lm-No-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc-456def")
+
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc-456def")
+
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "-"
+			result = stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_-Def_-Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc--Def--Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc--Def--Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "-"
+			result = stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_-Def_-Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc--Def--Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456-Def-G89-Hi-Jkl-Mn12")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456-Def-G89-Hi-Jkl-Mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-Abc~!-Def#-Ghi%-Jk-Lm-No-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "-"
+			result = stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-_-Def-_-Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc---Def---Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc---Def---Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+
+			opts.Separators = "_"
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "-"
+			result = stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-_-Def-_-Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc---Def---Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc-123-456-Def-G-89-Hi-Jkl-Mn-12")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc-123-456-Def-G-89-Hi-Jkl-Mn-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-Abc-~!-Def-#-Ghi-%-Jk-Lm-No-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
+
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
+
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "-"
+			result = stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc--Def--Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "-"
+			result = stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456def-G89hi-Jkl-Mn12")
+
+			opts.Separators = "_"
+			result = stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456def-G89hi-Jkl-Mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!-Def#-Ghi%-Jk-Lm-No-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "_"
+			result = stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-_def-_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc--def--ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc---Def---Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "_"
+			result = stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-_def-_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc-123-456def-G-89hi-Jkl-Mn-12")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc-123-456def-G-89hi-Jkl-Mn-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc-~!-Def-#-Ghi-%-Jk-Lm-No-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc-456def")
+
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc-456def")
+
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc-456-Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "_"
+			result = stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_-Def_-Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc--Def--Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc--Def--Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "_"
+			result = stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_-Def_-Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc--Def--Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456-Def-G89-Hi-Jkl-Mn12")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456-Def-G89-Hi-Jkl-Mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-Abc~!-Def#-Ghi%-Jk-Lm-No-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+			origOpts := stringcase.Options{
+				SeparateBeforeNonAlphabets: true,
+				SeparateAfterNonAlphabets:  true,
+			}
+
+			t.Run("convert camelCase", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "-_"
+				result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+				assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+			})
+
+			t.Run("convert PascalCase", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "-_"
+				result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+				assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+			})
+
+			t.Run("convert snake_case", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "-"
+				result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+				assert.Equal(t, result, "Abc-Def-Ghi")
+
+				opts.Keep = "_"
+				result = stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+				assert.Equal(t, result, "Abc-_-Def-_-Ghi")
+			})
+
+			t.Run("convert kebab-case", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "_"
+				result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+				assert.Equal(t, result, "Abc-Def-Ghi")
+
+				opts.Keep = "-"
+				result = stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+				assert.Equal(t, result, "Abc---Def---Ghi")
+			})
+
+			t.Run("convert Train-Case", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "_"
+				result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+				assert.Equal(t, result, "Abc-Def-Ghi")
+
+				opts.Keep = "-"
+				result = stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+				assert.Equal(t, result, "Abc---Def---Ghi")
+			})
+
+			t.Run("convert MACRO_CASE", func(t *testing.T) {
+				opts := origOpts
+
+				opts.Keep = "-"
+				result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+				assert.Equal(t, result, "Abc-Def-Ghi")
+
+				opts.Keep = "_"
+				result = stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+				assert.Equal(t, result, "Abc-_-Def-_-Ghi")
+			})
+
+			t.Run("convert COBOL-CASE", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "_"
+				result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+				assert.Equal(t, result, "Abc-Def-Ghi")
+
+				opts.Keep = "-"
+				result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+				assert.Equal(t, result, "Abc---Def---Ghi")
+			})
+
+			t.Run("convert with keeping digits", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "_"
+				result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+				assert.Equal(t, result, "Abc-123-456-Def-G-89-Hi-Jkl-Mn-12")
+
+				opts.Keep = "-"
+				result = stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+				assert.Equal(t, result, "Abc-123-456-Def-G-89-Hi-Jkl-Mn-12")
+			})
+
+			t.Run("convert with symbols as separators", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = ".~!#%?"
+				result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+				assert.Equal(t, result, ".-Abc-~!-Def-#-Ghi-%-Jk-Lm-No-?")
+			})
+
+			t.Run("convert when starting with digit", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "-_"
+				result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+				assert.Equal(t, result, "123-Abc-456-Def")
+
+				result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+				assert.Equal(t, result, "123-Abc-456-Def")
+
+				result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+				assert.Equal(t, result, "123-Abc-456-Def")
+			})
+
+			t.Run("convert an empty string", func(t *testing.T) {
+				opts := origOpts
+				opts.Keep = "-_"
+				result := stringcase.TrainCaseWithOptions("", opts)
+				assert.Equal(t, result, "")
+			})
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "Abc-Def-Gh-Ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "_"
+			result = stringcase.TrainCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc--Def--Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "_"
+			result = stringcase.TrainCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456def-G89hi-Jkl-Mn12")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456def-G89hi-Jkl-Mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.TrainCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!-Def#-Ghi%-Jk-Lm-No-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.TrainCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.TrainCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-Abc456-Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.TrainCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 }


### PR DESCRIPTION
(Related #5)

This PR adds the new function `TrainCaseWithOptions`, which supports handling non alphabetical characters, separators, and kept characters with Options.

In addition, the existing `TrainCase`, `TrainCaseWithSep`, and  `TrainCaseWithKeep` are changed to use this function inside.