### PR TITLE
fix!: made alphabets and numbers in separators no effect

### DIFF
--- a/snake_case.go
+++ b/snake_case.go
@@ -51,16 +51,14 @@ func SnakeCaseWithOptions(input string, opts Options) string {
 			flag = ChIsOther
 		} else {
 			isKeptChar := false
-			if len(opts.Separators) > 0 {
+			if isAsciiDigit(ch) {
+				isKeptChar = true
+			} else if len(opts.Separators) > 0 {
 				if !strings.ContainsRune(opts.Separators, ch) {
 					isKeptChar = true
 				}
 			} else if len(opts.Keep) > 0 {
-				if isAsciiDigit(ch) || strings.ContainsRune(opts.Keep, ch) {
-					isKeptChar = true
-				}
-			} else {
-				if isAsciiDigit(ch) {
+				if strings.ContainsRune(opts.Keep, ch) {
 					isKeptChar = true
 				}
 			}

--- a/snake_case_test.go
+++ b/snake_case_test.go
@@ -453,6 +453,13 @@ func TestSnakeCaseWithOptions(t *testing.T) {
 			result := stringcase.SnakeCaseWithOptions("", opts)
 			assert.Equal(t, result, "")
 		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.SnakeCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc_123def")
+		})
 	})
 
 	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
@@ -563,6 +570,13 @@ func TestSnakeCaseWithOptions(t *testing.T) {
 			opts.Separators = "-_"
 			result := stringcase.SnakeCaseWithOptions("", opts)
 			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.SnakeCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123_def")
 		})
 	})
 
@@ -675,6 +689,13 @@ func TestSnakeCaseWithOptions(t *testing.T) {
 			result := stringcase.SnakeCaseWithOptions("", opts)
 			assert.Equal(t, result, "")
 		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.SnakeCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc_123_def")
+		})
 	})
 
 	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
@@ -785,6 +806,13 @@ func TestSnakeCaseWithOptions(t *testing.T) {
 			opts.Separators = "-_"
 			result := stringcase.SnakeCaseWithOptions("", opts)
 			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.SnakeCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123def")
 		})
 	})
 

--- a/train_case.go
+++ b/train_case.go
@@ -56,16 +56,14 @@ func TrainCaseWithOptions(input string, opts Options) string {
 			flag = ChIsOther
 		} else {
 			isKeptChar := false
-			if len(opts.Separators) > 0 {
+			if isAsciiDigit(ch) {
+				isKeptChar = true
+			} else if len(opts.Separators) > 0 {
 				if !strings.ContainsRune(opts.Separators, ch) {
 					isKeptChar = true
 				}
 			} else if len(opts.Keep) > 0 {
-				if isAsciiDigit(ch) || strings.ContainsRune(opts.Keep, ch) {
-					isKeptChar = true
-				}
-			} else {
-				if isAsciiDigit(ch) {
+				if strings.ContainsRune(opts.Keep, ch) {
 					isKeptChar = true
 				}
 			}

--- a/train_case_test.go
+++ b/train_case_test.go
@@ -456,6 +456,13 @@ func TestTrainCaseWithOptions(t *testing.T) {
 			result := stringcase.TrainCaseWithOptions("", opts)
 			assert.Equal(t, result, "")
 		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.TrainCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "Abc-123def")
+		})
 	})
 
 	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
@@ -569,6 +576,13 @@ func TestTrainCaseWithOptions(t *testing.T) {
 			opts.Separators = "-_"
 			result := stringcase.TrainCaseWithOptions("", opts)
 			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.TrainCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "Abc123-Def")
 		})
 	})
 
@@ -685,6 +699,13 @@ func TestTrainCaseWithOptions(t *testing.T) {
 			result := stringcase.TrainCaseWithOptions("", opts)
 			assert.Equal(t, result, "")
 		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.TrainCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "Abc-123-Def")
+		})
 	})
 
 	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
@@ -798,6 +819,13 @@ func TestTrainCaseWithOptions(t *testing.T) {
 			opts.Separators = "-_"
 			result := stringcase.TrainCaseWithOptions("", opts)
 			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.TrainCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "Abc123def")
 		})
 	})
 


### PR DESCRIPTION
Before this modification, numbers in separators are treated as separators as well as symbols.