### PR TITLE
new!: added MacroCaseWithOptions, updated MacroCase to use it, and deprecated MacroCaseWithSep/Keep

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -166,6 +166,124 @@ func BenchmarkTrainCase_withKeep(b *testing.B) {
 	}
 }
 
+// macro case with options
+
+func BenchmarkMacroCase_nonAlphabetsAsHead(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsTail(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsWord(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsPart(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsHead_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsTail_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsWord_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsPart_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsHead_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsTail_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsWord_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkMacroCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.MacroCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
 
 // snake case with options
 

--- a/example_macro_case_test.go
+++ b/example_macro_case_test.go
@@ -8,20 +8,89 @@ import (
 
 func ExampleMacroCase() {
 	macro := stringcase.MacroCase("fooBarBaz")
-	fmt.Printf("macro = %s\n", macro)
+	fmt.Printf("(1) macro = %s\n", macro)
+
+	macro = stringcase.MacroCase("foo-Bar100baz")
+	fmt.Printf("(2) macro = %s\n", macro)
 	// Output:
-	// macro = FOO_BAR_BAZ
+	// (1) macro = FOO_BAR_BAZ
+	// (2) macro = FOO_BAR100_BAZ
+}
+
+func ExampleMacroCaseWithOptions() {
+	opts := stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true}
+	macro := stringcase.MacroCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(1) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(2) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(3) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(4) macro = %s\n\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Separators: "#"}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(5) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Separators: "#"}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(6) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Separators: "#"}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(7) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Separators: "#"}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(8) macro = %s\n\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Keep: "%"}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(9) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Keep: "%"}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(a) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Keep: "%"}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(b) macro = %s\n", macro)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Keep: "%"}
+	macro = stringcase.MacroCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(c) macro = %s\n", macro)
+	// Output:
+	// (1) macro = FOO_BAR100_BAZ
+	// (2) macro = FOO_BAR_100_BAZ
+	// (3) macro = FOO_BAR_100BAZ
+	// (4) macro = FOO_BAR100BAZ
+	//
+	// (5) macro = FOO_BAR100%_BAZ
+	// (6) macro = FOO_BAR_100%_BAZ
+	// (7) macro = FOO_BAR_100%BAZ
+	// (8) macro = FOO_BAR100%BAZ
+	//
+	// (9) macro = FOO_BAR100%_BAZ
+	// (a) macro = FOO_BAR_100%_BAZ
+	// (b) macro = FOO_BAR_100%BAZ
+	// (c) macro = FOO_BAR100%BAZ
 }
 
 func ExampleMacroCaseWithSep() {
-	macro := stringcase.MacroCaseWithSep("foo-Bar100%Baz", "- ")
+	macro := stringcase.MacroCaseWithSep("foo-bar100%baz", "- ")
 	fmt.Printf("macro = %s\n", macro)
 	// Output:
 	// macro = FOO_BAR100%_BAZ
 }
 
 func ExampleMacroCaseWithKeep() {
-	macro := stringcase.MacroCaseWithKeep("foo-Bar100%Baz", "%")
+	macro := stringcase.MacroCaseWithKeep("foo-bar100%baz", "%")
 	fmt.Printf("macro = %s\n", macro)
 	// Output:
 	// macro = FOO_BAR100%_BAZ

--- a/macro_case.go
+++ b/macro_case.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
@@ -8,197 +8,118 @@ import (
 	"strings"
 )
 
-// Converts a string to macro case.
+// MacroCaseWithOptions converts the input string to macro case with the
+// specified options.
+func MacroCaseWithOptions(input string, opts Options) string {
+	result := make([]rune, 0, len(input)+len(input)/2)
+
+	const (
+		ChIsFirstOfStr = iota
+		ChIsNextOfUpper
+		ChIsNextOfContdUpper
+		ChIsNextOfSepMark
+		ChIsNextOfKeptMark
+		ChIsOther
+	)
+	var flag uint8 = ChIsFirstOfStr
+
+	for _, ch := range input {
+		if isAsciiUpperCase(ch) {
+			if flag == ChIsFirstOfStr {
+				result = append(result, ch)
+				flag = ChIsNextOfUpper
+			} else if flag == ChIsNextOfUpper || flag == ChIsNextOfContdUpper ||
+				(!opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, ch)
+				flag = ChIsNextOfContdUpper
+			} else {
+				result = append(result, '_', ch)
+				flag = ChIsNextOfUpper
+			}
+		} else if isAsciiLowerCase(ch) {
+			if flag == ChIsNextOfContdUpper {
+				n := len(result)
+				prev := result[n-1]
+				result[n-1] = '_'
+				result = append(result, prev, toAsciiUpperCase(ch))
+			} else if flag == ChIsNextOfSepMark ||
+				(opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, '_', toAsciiUpperCase(ch))
+			} else {
+				result = append(result, toAsciiUpperCase(ch))
+			}
+			flag = ChIsOther
+		} else {
+			isKeptChar := false
+			if isAsciiDigit(ch) {
+				isKeptChar = true
+			} else if len(opts.Separators) > 0 {
+				if !strings.ContainsRune(opts.Separators, ch) {
+					isKeptChar = true
+				}
+			} else if len(opts.Keep) > 0 {
+				if strings.ContainsRune(opts.Keep, ch) {
+					isKeptChar = true
+				}
+			}
+
+			if isKeptChar {
+				if opts.SeparateBeforeNonAlphabets {
+					if flag == ChIsFirstOfStr || flag == ChIsNextOfKeptMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '_', ch)
+					}
+				} else {
+					if flag != ChIsNextOfSepMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '_', ch)
+					}
+				}
+				flag = ChIsNextOfKeptMark
+			} else {
+				if flag != ChIsFirstOfStr {
+					flag = ChIsNextOfSepMark
+				}
+			}
+		}
+	}
+
+	return string(result)
+}
+
+// MacroCase converts the input string to macro case.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is macro case.
-//
-// This function targets the upper and lower cases of ASCII alphabets for
-// capitalization, and all characters except ASCII alphabets and ASCII numbers
-// are eliminated as word separators.
+// It treats the end of a sequence of non-alphabetical characters as a
+// word boundary, but not the beginning.
 func MacroCase(input string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, ch)
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '_', ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '_'
-				result = append(result, prev, toAsciiUpperCase(ch))
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '_', toAsciiUpperCase(ch))
-			default:
-				result = append(result, toAsciiUpperCase(ch))
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '_', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+	return MacroCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	})
 }
 
-// Converts a string to macro case using the specified characters as
-// separators.
+// MacroCaseWithSep converts the input string to macro case with the
+// specified separator characters.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is macro case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters specified as the second argument of this
-// function are regarded as word separators and are replaced to underscores.
-func MacroCaseWithSep(input, seps string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, ch)
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '_', ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '_'
-				result = append(result, prev, toAsciiUpperCase(ch))
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '_', toAsciiUpperCase(ch))
-			default:
-				result = append(result, toAsciiUpperCase(ch))
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '_', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use MacroCaseWithOptions instead
+func MacroCaseWithSep(input string, seps string) string {
+	return MacroCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 seps,
+	})
 }
 
-// Converts a string to macro case using characters other than the specified
-// characters as separators.
+// MacroCaseWithKeep converts the input string to macro case with the
+// specified characters to be kept.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is macro case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters other than the specified characters as
-// the second argument of this function are regarded as word separators and
-// are replaced to underscores.
-func MacroCaseWithKeep(input, keeped string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, ch)
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '_', ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '_'
-				result = append(result, prev, toAsciiUpperCase(ch))
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '_', toAsciiUpperCase(ch))
-			default:
-				result = append(result, toAsciiUpperCase(ch))
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || strings.ContainsRune(keeped, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '_', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use MacroCaseWithOptions instead
+func MacroCaseWithKeep(input string, kept string) string {
+	return MacroCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       kept,
+	})
 }

--- a/macro_case_test.go
+++ b/macro_case_test.go
@@ -8,200 +8,1251 @@ import (
 	"github.com/sttk/stringcase"
 )
 
-func TestMacroCase_convertCamelCase(t *testing.T) {
-	result := stringcase.MacroCase("abcDefGHIjk")
-	assert.Equal(t, result, "ABC_DEF_GH_IJK")
+func TestMacroCase(t *testing.T) {
+	t.Run("convert camelCase", func(t *testing.T) {
+		result := stringcase.MacroCase("abcDefGHIjk")
+		assert.Equal(t, result, "ABC_DEF_GH_IJK")
+	})
+
+	t.Run("convert PascalCase", func(t *testing.T) {
+		result := stringcase.MacroCase("AbcDefGHIjk")
+		assert.Equal(t, result, "ABC_DEF_GH_IJK")
+	})
+
+	t.Run("convert snake_case", func(t *testing.T) {
+		result := stringcase.MacroCase("abc_def_ghi")
+		assert.Equal(t, result, "ABC_DEF_GHI")
+	})
+
+	t.Run("convert kebab-case", func(t *testing.T) {
+		result := stringcase.MacroCase("abc-def-ghi")
+		assert.Equal(t, result, "ABC_DEF_GHI")
+	})
+
+	t.Run("convert Train-Case", func(t *testing.T) {
+		result := stringcase.MacroCase("Abc-Def-Ghi")
+		assert.Equal(t, result, "ABC_DEF_GHI")
+	})
+
+	t.Run("convert MACRO_CASE", func(t *testing.T) {
+		result := stringcase.MacroCase("ABC_DEF_GHI")
+		assert.Equal(t, result, "ABC_DEF_GHI")
+	})
+
+	t.Run("convert COBOL-CASE", func(t *testing.T) {
+		result := stringcase.MacroCase("ABC-DEF-GHI")
+		assert.Equal(t, result, "ABC_DEF_GHI")
+	})
+
+	t.Run("convert with keeping digits", func(t *testing.T) {
+		result := stringcase.MacroCase("abc123-456defG89HIJklMN12")
+		assert.Equal(t, result, "ABC123_456_DEF_G89_HI_JKL_MN12")
+	})
+
+	t.Run("convert with symbols as separators", func(t *testing.T) {
+		result := stringcase.MacroCase(":.abc~!@def#$ghi%&jk(lm)no/?")
+		assert.Equal(t, result, "ABC_DEF_GHI_JK_LM_NO")
+	})
+
+	t.Run("convert when starting with digit", func(t *testing.T) {
+		result := stringcase.MacroCase("123abc456def")
+		assert.Equal(t, result, "123_ABC456_DEF")
+
+		result = stringcase.MacroCase("123ABC456DEF")
+		assert.Equal(t, result, "123_ABC456_DEF")
+
+		result = stringcase.MacroCase("123Abc456Def")
+		assert.Equal(t, result, "123_ABC456_DEF")
+	})
+
+	t.Run("convert an empty string", func(t *testing.T) {
+		result := stringcase.MacroCase("")
+		assert.Equal(t, result, "")
+	})
 }
 
-func TestMacroCase_convertPascalCase(t *testing.T) {
-	result := stringcase.MacroCase("AbcDefGHIjk")
-	assert.Equal(t, result, "ABC_DEF_GH_IJK")
-}
+func TestMacroCaseWithOptions(t *testing.T) {
+	t.Run("non-alphabets as head of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestMacroCase_convertSnakeCase(t *testing.T) {
-	result := stringcase.MacroCase("abc_def_ghi")
-	assert.Equal(t, result, "ABC_DEF_GHI")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
 
-func TestMacroCase_convertKebabCase(t *testing.T) {
-	result := stringcase.MacroCase("abc-def-ghi")
-	assert.Equal(t, result, "ABC_DEF_GHI")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
 
-func TestMacroCase_convertTrainCase(t *testing.T) {
-	result := stringcase.MacroCase("Abc-Def-Ghi")
-	assert.Equal(t, result, "ABC_DEF_GHI")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCase_convertMacroCase(t *testing.T) {
-	result := stringcase.MacroCase("ABC_DEF_GHI")
-	assert.Equal(t, result, "ABC_DEF_GHI")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCase_convertCobolCase(t *testing.T) {
-	result := stringcase.MacroCase("ABC-DEF-GHI")
-	assert.Equal(t, result, "ABC_DEF_GHI")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCase_keepDigits(t *testing.T) {
-	result := stringcase.MacroCase("abc123-456defG89HIJklMN12")
-	assert.Equal(t, result, "ABC123_456_DEF_G89_HI_JKL_MN12")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCase_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.MacroCase("123abc456def")
-	assert.Equal(t, result, "123_ABC456_DEF")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-	result = stringcase.MacroCase("123ABC456DEF")
-	assert.Equal(t, result, "123_ABC456_DEF")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123_456DEF_G_89HI_JKL_MN_12")
+		})
 
-func TestMacroCase_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.MacroCase(":.abc~!@def#$ghi%&jk(lm)no/?")
-	assert.Equal(t, result, "ABC_DEF_GHI_JK_LM_NO")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI_JK_LM_NO")
+		})
 
-func TestMacroCase_convertEmpty(t *testing.T) {
-	result := stringcase.MacroCase("")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC_456DEF")
 
-///
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC_456DEF")
 
-func TestMacroCaseWithSep_convertCamelCase(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "ABC_DEF_GH_IJK")
-}
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+		})
 
-func TestMacroCaseWithSep_convertPascalCase(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "ABC_DEF_GH_IJK")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestMacroCaseWithSep_convertKebabCase(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("abc-def-ghi", "-")
-	assert.Equal(t, result, "ABC_DEF_GHI")
+	t.Run("non-alphabets as tail of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-	result = stringcase.MacroCaseWithSep("abc-def-ghi", "_")
-	assert.Equal(t, result, "ABC-_DEF-_GHI")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
 
-func TestMacroCaseWithSep_convertTrainCase(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "ABC_DEF_GHI")
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
 
-	result = stringcase.MacroCaseWithSep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "ABC-_DEF-_GHI")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCaseWithSep_convertMacroCase(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "ABC_DEF_GHI")
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-	result = stringcase.MacroCaseWithSep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "ABC__DEF__GHI")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCaseWithSep_convertCobolCase(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "ABC_DEF_GHI")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-	result = stringcase.MacroCaseWithSep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "ABC-_DEF-_GHI")
-}
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCaseWithSep_keepDigits(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("abc123-456defG89HIJklMN12", "-")
-	assert.Equal(t, result, "ABC123_456_DEF_G89_HI_JKL_MN12")
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123_456_DEF_G89_HI_JKL_MN12")
+		})
 
-	result = stringcase.MacroCaseWithSep("abc123-456defG89HIJklMN12", "_")
-	assert.Equal(t, result, "ABC123-456_DEF_G89_HI_JKL_MN12")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI_JK_LM_NO")
+		})
 
-func TestMacroCaseWithSep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("123abc456def", "_")
-	assert.Equal(t, result, "123_ABC456_DEF")
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
 
-	result = stringcase.MacroCaseWithSep("123ABC456DEF", "_")
-	assert.Equal(t, result, "123_ABC456_DEF")
-}
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
 
-func TestMacroCaseWithSep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.MacroCaseWithSep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/")
-	assert.Equal(t, result, "._ABC~!_DEF#_GHI%_JK_LM_NO_?")
-}
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+		})
 
-func TestMacroCaseWithSep_convertEmpty(t *testing.T) {
-	result := stringcase.MacroCaseWithSep("", "-_")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-///
+	t.Run("non-alphabets as a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-func TestMacroCaseWithKeep_convertCamelCase(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "ABC_DEF_GH_IJK")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
 
-func TestMacroCaseWithKeep_convertPascalCase(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "ABC_DEF_GH_IJK")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
 
-func TestMacroCaseWithKeep_convertKebabCase(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("abc-def-ghi", "_")
-	assert.Equal(t, result, "ABC_DEF_GHI")
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-	result = stringcase.MacroCaseWithKeep("abc-def-ghi", "-")
-	assert.Equal(t, result, "ABC-_DEF-_GHI")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCaseWithKeep_convertTrainCase(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "ABC_DEF_GHI")
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-	result = stringcase.MacroCaseWithKeep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "ABC-_DEF-_GHI")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-func TestMacroCaseWithKeep_convertMacroCase(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "ABC_DEF_GHI")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
 
-	result = stringcase.MacroCaseWithKeep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "ABC__DEF__GHI")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123_456_DEF_G_89_HI_JKL_MN_12")
+		})
 
-func TestMacroCaseWithKeep_convertCobolCase(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "ABC_DEF_GHI")
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI_JK_LM_NO")
+		})
 
-	result = stringcase.MacroCaseWithKeep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "ABC-_DEF-_GHI")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
 
-func TestMacroCaseWithKeep_keepDigits(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("abc123-456defG89HIJklMN12", "_")
-	assert.Equal(t, result, "ABC123_456_DEF_G89_HI_JKL_MN12")
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
 
-	result = stringcase.MacroCaseWithKeep("abc123-456defG89HIJklMN12", "-")
-	assert.Equal(t, result, "ABC123-456_DEF_G89_HI_JKL_MN12")
-}
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+		})
 
-func TestMacroCaseWithKeep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("123abc456def", "_")
-	assert.Equal(t, result, "123_ABC456_DEF")
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-	result = stringcase.MacroCaseWithKeep("123ABC456DEF", "_")
-	assert.Equal(t, result, "123_ABC456_DEF")
-}
+	t.Run("non-alphabets as part of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestMacroCaseWithKeep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?")
-	assert.Equal(t, result, "._ABC~!_DEF#_GHI%_JK_LM_NO_?")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
 
-func TestMacroCaseWithKeep_convertEmpty(t *testing.T) {
-	result := stringcase.MacroCaseWithKeep("", "_-")
-	assert.Equal(t, result, "")
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123_456DEF_G89HI_JKL_MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI_JK_LM_NO")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "-"
+			result = stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC__DEF__GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_-DEF_-GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_-_DEF_-_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "-"
+			result = stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC__DEF__GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_-DEF_-GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123_456DEF_G_89HI_JKL_MN_12")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123-456DEF_G_89HI_JKL_MN_12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".ABC_~!_DEF_#_GHI_%_JK_LM_NO_?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC_456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC_456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "-"
+			result = stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC__DEF__GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "-"
+			result = stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC__DEF__GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123_456_DEF_G89_HI_JKL_MN12")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456_DEF_G89_HI_JKL_MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "._ABC~!_DEF#_GHI%_JK_LM_NO_?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "-"
+			result = stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC___DEF___GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_-_DEF_-_GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_-_DEF_-_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "-"
+			result = stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC___DEF___GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_-_DEF_-_GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123_456_DEF_G_89_HI_JKL_MN_12")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123-456_DEF_G_89_HI_JKL_MN_12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "._ABC_~!_DEF_#_GHI_%_JK_LM_NO_?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "-"
+			result = stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "-"
+			result = stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123_456DEF_G89HI_JKL_MN12")
+
+			opts.Separators = "_"
+			result = stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456DEF_G89HI_JKL_MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".ABC~!_DEF#_GHI%_JK_LM_NO_?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC__DEF__GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_-DEF_-GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_-_DEF_-_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "_"
+			result = stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC__DEF__GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_-DEF_-GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123_456DEF_G_89HI_JKL_MN_12")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123-456DEF_G_89HI_JKL_MN_12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".ABC_~!_DEF_#_GHI_%_JK_LM_NO_?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC_456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC_456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "_"
+			result = stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC__DEF__GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "_"
+			result = stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC__DEF__GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123_456_DEF_G89_HI_JKL_MN12")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456_DEF_G89_HI_JKL_MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "._ABC~!_DEF#_GHI%_JK_LM_NO_?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "_"
+			result = stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC___DEF___GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_-_DEF_-_GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_-_DEF_-_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "_"
+			result = stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC___DEF___GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_-_DEF_-_GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123_456_DEF_G_89_HI_JKL_MN_12")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC_123-456_DEF_G_89_HI_JKL_MN_12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "._ABC_~!_DEF_#_GHI_%_JK_LM_NO_?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC_456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC_DEF_GH_IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "_"
+			result = stringcase.MacroCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "_"
+			result = stringcase.MacroCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123_456DEF_G89HI_JKL_MN12")
+
+			opts.Keep = "-"
+			result = stringcase.MacroCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456DEF_G89HI_JKL_MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.MacroCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".ABC~!_DEF#_GHI%_JK_LM_NO_?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.MacroCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123_ABC456_DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.MacroCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 }


### PR DESCRIPTION
(Related #5)

This PR adds the new function `MacroCaseWithOptions`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`MacroCase` is changed to use this function inside, and both `MacroCaseWithSep` and `MacroCaseWithKeep` are deprecated.