### PR TITLE
new!: added KebabCaseWithOptions, updated KebabCase to use it, and deprecated KebabCaseWithSep/Keep

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -166,6 +166,125 @@ func BenchmarkTrainCase_withKeep(b *testing.B) {
 	}
 }
 
+// kebab case with options
+
+func BenchmarkKebabCase_nonAlphabetsAsHead(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsTail(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsWord(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsPart(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsHead_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsTail_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsWord_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsPart_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsHead_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsTail_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsWord_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkKebabCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.KebabCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
 // macro case with options
 
 func BenchmarkMacroCase_nonAlphabetsAsHead(b *testing.B) {

--- a/example_kebab_case_test.go
+++ b/example_kebab_case_test.go
@@ -8,13 +8,82 @@ import (
 
 func ExampleKebabCase() {
 	kebab := stringcase.KebabCase("fooBarBaz")
-	fmt.Printf("kebab = %s\n", kebab)
+	fmt.Printf("(1) kebab = %s\n", kebab)
+
+	kebab = stringcase.KebabCase("foo-Bar100baz")
+	fmt.Printf("(2) kebab = %s\n", kebab)
 	// Output:
-	// kebab = foo-bar-baz
+	// (1) kebab = foo-bar-baz
+	// (2) kebab = foo-bar100-baz
+}
+
+func ExampleKebabCaseWithOptions() {
+	opts := stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true}
+	kebab := stringcase.KebabCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(1) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(2) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(3) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(4) kebab = %s\n\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Separators: "#"}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(5) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Separators: "#"}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(6) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Separators: "#"}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(7) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Separators: "#"}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(8) kebab = %s\n\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Keep: "%"}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(9) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Keep: "%"}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(a) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Keep: "%"}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(b) kebab = %s\n", kebab)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Keep: "%"}
+	kebab = stringcase.KebabCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(c) kebab = %s\n", kebab)
+	// Output:
+	// (1) kebab = foo-bar100-baz
+	// (2) kebab = foo-bar-100-baz
+	// (3) kebab = foo-bar-100baz
+	// (4) kebab = foo-bar100baz
+	//
+	// (5) kebab = foo-bar100%-baz
+	// (6) kebab = foo-bar-100%-baz
+	// (7) kebab = foo-bar-100%baz
+	// (8) kebab = foo-bar100%baz
+	//
+	// (9) kebab = foo-bar100%-baz
+	// (a) kebab = foo-bar-100%-baz
+	// (b) kebab = foo-bar-100%baz
+	// (c) kebab = foo-bar100%baz
 }
 
 func ExampleKebabCaseWithSep() {
-	kebab := stringcase.KebabCaseWithSep("foo-bar100%baz", "- ")
+	kebab := stringcase.KebabCaseWithSep("foo-Bar100%Baz", "- ")
 	fmt.Printf("kebab = %s\n", kebab)
 	// Output:
 	// kebab = foo-bar100%-baz

--- a/kebab_case.go
+++ b/kebab_case.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
@@ -8,198 +8,118 @@ import (
 	"strings"
 )
 
-// Converts a string to kebab case.
+// KebabCaseWithOptions converts the input string to kebab case with the
+// specified options.
+func KebabCaseWithOptions(input string, opts Options) string {
+	result := make([]rune, 0, len(input)+len(input)/2)
+
+	const (
+		ChIsFirstOfStr = iota
+		ChIsNextOfUpper
+		ChIsNextOfContdUpper
+		ChIsNextOfSepMark
+		ChIsNextOfKeptMark
+		ChIsOther
+	)
+	var flag uint8 = ChIsFirstOfStr
+
+	for _, ch := range input {
+		if isAsciiUpperCase(ch) {
+			if flag == ChIsFirstOfStr {
+				result = append(result, toAsciiLowerCase(ch))
+				flag = ChIsNextOfUpper
+			} else if flag == ChIsNextOfUpper || flag == ChIsNextOfContdUpper ||
+				(!opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, toAsciiLowerCase(ch))
+				flag = ChIsNextOfContdUpper
+			} else {
+				result = append(result, '-', toAsciiLowerCase(ch))
+				flag = ChIsNextOfUpper
+			}
+		} else if isAsciiLowerCase(ch) {
+			if flag == ChIsNextOfContdUpper {
+				n := len(result)
+				prev := result[n-1]
+				result[n-1] = '-'
+				result = append(result, prev, ch)
+			} else if flag == ChIsNextOfSepMark ||
+				(opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, '-', ch)
+			} else {
+				result = append(result, ch)
+			}
+			flag = ChIsOther
+		} else {
+			isKeptChar := false
+			if isAsciiDigit(ch) {
+				isKeptChar = true
+			} else if len(opts.Separators) > 0 {
+				if !strings.ContainsRune(opts.Separators, ch) {
+					isKeptChar = true
+				}
+			} else if len(opts.Keep) > 0 {
+				if strings.ContainsRune(opts.Keep, ch) {
+					isKeptChar = true
+				}
+			}
+
+			if isKeptChar {
+				if opts.SeparateBeforeNonAlphabets {
+					if flag == ChIsFirstOfStr || flag == ChIsNextOfKeptMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '-', ch)
+					}
+				} else {
+					if flag != ChIsNextOfSepMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '-', ch)
+					}
+				}
+				flag = ChIsNextOfKeptMark
+			} else {
+				if flag != ChIsFirstOfStr {
+					flag = ChIsNextOfSepMark
+				}
+			}
+		}
+	}
+
+	return string(result)
+}
+
+// KebabCase converts the input string to kebab case.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is kebab case.
-//
-// This function targets the upper and lower cases of ASCII alphabets for
-// capitalization, and all characters except ASCII alphabets and ASCII numbers
-// are eliminated as word separators.
+// It treats the end of a sequence of non-alphabetical characters as a
+// word boundary, but not the beginning.
 func KebabCase(input string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-')
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '-'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-', ch)
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '-', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+	return KebabCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	})
 }
 
-// Converts a string to kebab case using the specified characters as
-// separators.
+// KebabCaseWithSep converts the input string to kebab case with the
+// specified separator characters.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is kebab case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters specified as the second argument of this
-// function are regarded as word separators and are replaced to hyphens.
-func KebabCaseWithSep(input, seps string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-', toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '-'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-', ch)
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '-', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use KebabCaseWithOptions instead
+func KebabCaseWithSep(input string, seps string) string {
+	return KebabCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 seps,
+	})
 }
 
-// Converts a string to kebab case using characters other than the specified
-// characters as separators.
+// KebabCaseWithSep converts the input string to kebab case with the
+// specified separator characters.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is kebab case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters other than the specified characters as
-// the second argument of this function are regarded as word separators and
-// are replaced to hyphens.
-func KebabCaseWithKeep(input, keeped string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-', toAsciiLowerCase(ch))
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '-'
-				result = append(result, prev, ch)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-', ch)
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || strings.ContainsRune(keeped, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '-', ch)
-			} else {
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use KebabCaseWithOptions instead
+func KebabCaseWithKeep(input string, kept string) string {
+	return KebabCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       kept,
+	})
 }

--- a/kebab_case_test.go
+++ b/kebab_case_test.go
@@ -8,216 +8,1719 @@ import (
 	"github.com/sttk/stringcase"
 )
 
-func TestKebabCase_convertCamelCase(t *testing.T) {
-	result := stringcase.KebabCase("abcDefGHIjk")
-	assert.Equal(t, result, "abc-def-gh-ijk")
+func TestKebabCase(t *testing.T) {
+	t.Run("convert camelCase", func(t *testing.T) {
+		result := stringcase.KebabCase("abcDefGHIjk")
+		assert.Equal(t, result, "abc-def-gh-ijk")
+	})
+
+	t.Run("convert PascalCase", func(t *testing.T) {
+		result := stringcase.KebabCase("AbcDefGHIjk")
+		assert.Equal(t, result, "abc-def-gh-ijk")
+	})
+
+	t.Run("convert snake_case", func(t *testing.T) {
+		result := stringcase.KebabCase("abc_def_ghi")
+		assert.Equal(t, result, "abc-def-ghi")
+	})
+
+	t.Run("convert kebab-case", func(t *testing.T) {
+		result := stringcase.KebabCase("abc-def-ghi")
+		assert.Equal(t, result, "abc-def-ghi")
+	})
+
+	t.Run("convert Trail-Case", func(t *testing.T) {
+		result := stringcase.KebabCase("Abc-Def-Ghi")
+		assert.Equal(t, result, "abc-def-ghi")
+	})
+
+	t.Run("convert MACRO_CASE", func(t *testing.T) {
+		result := stringcase.KebabCase("ABC_DEF_GHI")
+		assert.Equal(t, result, "abc-def-ghi")
+	})
+
+	t.Run("convert COBOL-CASE", func(t *testing.T) {
+		result := stringcase.KebabCase("ABC-DEF-GHI")
+		assert.Equal(t, result, "abc-def-ghi")
+	})
+
+	t.Run("convert with keeping digits", func(t *testing.T) {
+		result := stringcase.KebabCase("abc123-456defG89HIJklMN12")
+		assert.Equal(t, result, "abc123-456-def-g89-hi-jkl-mn12")
+	})
+
+	t.Run("convert with symbols as seperators", func(t *testing.T) {
+		result := stringcase.KebabCase(":.abc~!@def#$ghi%&jk(lm)no/?")
+		assert.Equal(t, result, "abc-def-ghi-jk-lm-no")
+	})
+
+	t.Run("convert when starting with digit", func(t *testing.T) {
+		result := stringcase.KebabCase("123abc456def")
+		assert.Equal(t, result, "123-abc456-def")
+
+		result = stringcase.KebabCase("123ABC456DEF")
+		assert.Equal(t, result, "123-abc456-def")
+
+		result = stringcase.KebabCase("123Abc456Def")
+		assert.Equal(t, result, "123-abc456-def")
+	})
+
+	t.Run("convert an empty string", func(t *testing.T) {
+		result := stringcase.KebabCase("")
+		assert.Equal(t, result, "")
+	})
 }
 
-func TestKebabCase_convertPascalCase(t *testing.T) {
-	result := stringcase.KebabCase("AbcDefGHIjk")
-	assert.Equal(t, result, "abc-def-gh-ijk")
-}
+func TestKebabCaseWithOptions(t *testing.T) {
+	t.Run("non-alphabets as head of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestKebabCase_convertSnakeCase(t *testing.T) {
-	result := stringcase.KebabCase("abc_def_ghi")
-	assert.Equal(t, result, "abc-def-ghi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
 
-func TestKebabCase_convertKebabCase(t *testing.T) {
-	result := stringcase.KebabCase("abc-def-ghi")
-	assert.Equal(t, result, "abc-def-ghi")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
 
-func TestKebabCase_convertTrainCase(t *testing.T) {
-	result := stringcase.KebabCase("Abc-Def-Ghi")
-	assert.Equal(t, result, "abc-def-ghi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCase_convertMacroCase(t *testing.T) {
-	result := stringcase.KebabCase("ABC_DEF_GHI")
-	assert.Equal(t, result, "abc-def-ghi")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCase_convertCobolCase(t *testing.T) {
-	result := stringcase.KebabCase("ABC-DEF-GHI")
-	assert.Equal(t, result, "abc-def-ghi")
-}
+		t.Run("convert Trail-Case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCase_keepDigits(t *testing.T) {
-	result := stringcase.KebabCase("abc123-456defG789HIJklMN12")
-	assert.Equal(t, result, "abc123-456-def-g789-hi-jkl-mn12")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCase_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.KebabCase("123abc456def")
-	assert.Equal(t, result, "123-abc456-def")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-	result = stringcase.KebabCase("123ABC456DEF")
-	assert.Equal(t, result, "123-abc456-def")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456def-g-89hi-jkl-mn-12")
+		})
 
-func TestKebabCase_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.KebabCase(":.abc~!@def#$ghi%&jk(lm)no/?")
-	assert.Equal(t, result, "abc-def-ghi-jk-lm-no")
-}
+		t.Run("convert with symbols as seperators", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abc-def-ghi-jk-lm-no")
+		})
 
-func TestKebabCase_convertEmpty(t *testing.T) {
-	result := stringcase.KebabCase("")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc-456def")
 
-///
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc-456def")
 
-func TestKebabCaseWithSep_convertCamelCase(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "abc-def-gh-ijk")
-}
+			result = stringcase.KebabCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-abc-456-def")
+		})
 
-func TestKebabCaseWithSep_convertPascalCase(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "abc-def-gh-ijk")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestKebabCaseWithSep_convertSnakeCase(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("abc_def_ghi", "_")
-	assert.Equal(t, result, "abc-def-ghi")
+	t.Run("non-alphabets as tail of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-	result = stringcase.KebabCaseWithSep("abc_def_ghi", "-")
-	assert.Equal(t, result, "abc_-def_-ghi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
 
-func TestKebabCaseWithSep_convertKebabCase(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("abc-def-ghi", "-")
-	assert.Equal(t, result, "abc-def-ghi")
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
 
-	result = stringcase.KebabCaseWithSep("abc-def-ghi", "_")
-	assert.Equal(t, result, "abc--def--ghi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCaseWithSep_convertTrainCase(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "abc-def-ghi")
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-	result = stringcase.KebabCaseWithSep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "abc--def--ghi")
-}
+		t.Run("convert Trail-Case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCaseWithSep_convertMacroCase(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "abc-def-ghi")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-	result = stringcase.KebabCaseWithSep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "abc_-def_-ghi")
-}
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCaseWithSep_convertCobolCase(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "abc-def-ghi")
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456-def-g89-hi-jkl-mn12")
+		})
 
-	result = stringcase.KebabCaseWithSep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "abc--def--ghi")
-}
+		t.Run("convert with symbols as seperators", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abc-def-ghi-jk-lm-no")
+		})
 
-func TestKebabCaseWithSep_keepDigits(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "abc123-456-def-g789-hi-jkl-mn12")
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-abc456-def")
 
-	result = stringcase.KebabCaseWithSep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "abc123-456-def-g789-hi-jkl-mn12")
-}
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-abc456-def")
 
-func TestKebabCaseWithSep_convertWithStartingWithDigit(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("123abc456def", "-")
-	assert.Equal(t, result, "123-abc456-def")
+			result = stringcase.KebabCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-abc456-def")
+		})
 
-	result = stringcase.KebabCaseWithSep("123ABC456DEF", "-")
-	assert.Equal(t, result, "123-abc456-def")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestKebabCaseWithSep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.KebabCaseWithSep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/")
-	assert.Equal(t, result, ".-abc~!-def#-ghi%-jk-lm-no-?")
-}
+	t.Run("non-alphabets as a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-func TestKebabCaseWithSep_convertEmpty(t *testing.T) {
-	result := stringcase.KebabCaseWithSep("", "-_")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
 
-///
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
 
-func TestKebabCaseWithKeep_convertCamelCase(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "abc-def-gh-ijk")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCaseWithKeep_convertPascalCase(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "abc-def-gh-ijk")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCaseWithKeep_convertSnakeCase(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("abc_def_ghi", "-")
-	assert.Equal(t, result, "abc-def-ghi")
+		t.Run("convert Trail-Case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-	result = stringcase.KebabCaseWithKeep("abc_def_ghi", "_")
-	assert.Equal(t, result, "abc_-def_-ghi")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCaseWithKeep_convertKebabCase(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("abc-def-ghi", "_")
-	assert.Equal(t, result, "abc-def-ghi")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-	result = stringcase.KebabCaseWithKeep("abc-def-ghi", "-")
-	assert.Equal(t, result, "abc--def--ghi")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456-def-g-89-hi-jkl-mn-12")
+		})
 
-func TestKebabCaseWithKeep_convertTrainCase(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "abc-def-ghi")
+		t.Run("convert with symbols as seperators", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abc-def-ghi-jk-lm-no")
+		})
 
-	result = stringcase.KebabCaseWithKeep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "abc--def--ghi")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-abc-456-def")
 
-func TestKebabCaseWithKeep_convertMacroCase(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "abc-def-ghi")
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-abc-456-def")
 
-	result = stringcase.KebabCaseWithKeep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "abc_-def_-ghi")
-}
+			result = stringcase.KebabCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-abc-456-def")
+		})
 
-func TestKebabCaseWithKeep_convertCobolCase(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "abc-def-ghi")
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-	result = stringcase.KebabCaseWithKeep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "abc--def--ghi")
-}
+	t.Run("non-alphabets as part of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestKebabCaseWithKeep_keepDigits(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "abc123-456-def-g789-hi-jkl-mn12")
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
 
-	result = stringcase.KebabCaseWithKeep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "abc123-456-def-g789-hi-jkl-mn12")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
 
-func TestKebabCaseWithKeep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("123abc456def", "-")
-	assert.Equal(t, result, "123-abc456-def")
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-	result = stringcase.KebabCaseWithKeep("123ABC456DEF", "-")
-	assert.Equal(t, result, "123-abc456-def")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCaseWithKeep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?")
-	assert.Equal(t, result, ".-abc~!-def#-ghi%-jk-lm-no-?")
-}
+		t.Run("convert Trail-Case", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
 
-func TestKebabCaseWithKeep_convertEmpty(t *testing.T) {
-	result := stringcase.KebabCaseWithKeep("", "-_")
-	assert.Equal(t, result, "")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def-g89hi-jkl-mn12")
+		})
+
+		t.Run("convert with symbols as seperators", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abc-def-ghi-jk-lm-no")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.KebabCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-abc456-def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456def-g-89hi-jkl-mn-12")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456def-g-89hi-jkl-mn-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc-~!-def-#-ghi-%-jk-lm-no-?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc-456def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc-456def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.KebabCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc-123def")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456-def-g89-hi-jkl-mn12")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456-def-g89-hi-jkl-mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-abc~!-def#-ghi%-jk-lm-no-?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-abc456-def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-abc456-def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.KebabCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123-def")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-_-def-_-ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-_-def-_-ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456-def-g-89-hi-jkl-mn-12")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456-def-g-89-hi-jkl-mn-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-abc-~!-def-#-ghi-%-jk-lm-no-?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-abc-456-def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-abc-456-def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.KebabCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc-123-def")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def-g89hi-jkl-mn12")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def-g89hi-jkl-mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!-def#-ghi%-jk-lm-no-?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.KebabCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123def")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456def-g-89hi-jkl-mn-12")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456def-g-89hi-jkl-mn-12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc-456def")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc-456def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc-~!-def-#-ghi-%-jk-lm-no-?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456-def-g89-hi-jkl-mn12")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456-def-g89-hi-jkl-mn12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-abc456-def")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-abc456-def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-abc~!-def#-ghi%-jk-lm-no-?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			t.Skip()
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-_-def-_-ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-_-def-_-ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456-def-g-89-hi-jkl-mn-12")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456-def-g-89-hi-jkl-mn-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-abc-~!-def-#-ghi-%-jk-lm-no-?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-abc-456-def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-abc-456-def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.KebabCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc-123-def")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "-"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def-g89hi-jkl-mn12")
+
+			opts.Separators = "_"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def-g89hi-jkl-mn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!-def#-ghi%-jk-lm-no-?")
+		})
+
+		t.Run("convert with starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.KebabCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123def")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-_def-_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456def-g-89hi-jkl-mn-12")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456def-g-89hi-jkl-mn-12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc-456def")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc-456def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc-~!-def-#-ghi-%-jk-lm-no-?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_-def_-ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456-def-g89-hi-jkl-mn12")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456-def-g89-hi-jkl-mn12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-abc456-def")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-abc456-def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-abc~!-def#-ghi%-jk-lm-no-?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-_-def-_-ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			t.Skip()
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc_-_def_-_ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-_-def-_-ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc---def---ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456-def-g-89-hi-jkl-mn-12")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc-123-456-def-g-89-hi-jkl-mn-12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-abc-456-def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-abc-456-def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-abc-~!-def-#-ghi-%-jk-lm-no-?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abc-def-gh-ijk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc--def--ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "_"
+			result = stringcase.KebabCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def-g89hi-jkl-mn12")
+
+			opts.Keep = "-"
+			result = stringcase.KebabCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456def-g89hi-jkl-mn12")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.KebabCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.KebabCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.KebabCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!-def#-ghi%-jk-lm-no-?")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.KebabCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 }


### PR DESCRIPTION
(Related #5)

This PR adds the new function `KebabCaseWithOptions`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`KebabCase` is changed to use this function inside, and both `KebabCaseWithSep` and `KebabCaseWithKeep` are deprecated.