### PR TITLE
new!: added CobolCaseWithOptions, updated CobolCase to use it, and deprecated CobolCaseWithSep/Keep

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -166,6 +166,125 @@ func BenchmarkTrainCase_withKeep(b *testing.B) {
 	}
 }
 
+// cobol case with options
+
+func BenchmarkCobolCase_nonAlphabetsAsHead(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsTail(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsWord(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsPart(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsHead_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsTail_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsWord_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsPart_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsHead_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsTail_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsWord_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCobolCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CobolCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
 // kebab case with options
 
 func BenchmarkKebabCase_nonAlphabetsAsHead(b *testing.B) {

--- a/cobol_case.go
+++ b/cobol_case.go
@@ -8,197 +8,118 @@ import (
 	"strings"
 )
 
-// Converts a string to cobol case.
+// CobolCaseWithOptions converts the input string to cobol case with the
+// specified options.
+func CobolCaseWithOptions(input string, opts Options) string {
+	result := make([]rune, 0, len(input)+len(input)/2)
+
+	const (
+		ChIsFirstOfStr = iota
+		ChIsNextOfUpper
+		ChIsNextOfContdUpper
+		ChIsNextOfSepMark
+		ChIsNextOfKeptMark
+		ChIsOther
+	)
+	var flag uint8 = ChIsFirstOfStr
+
+	for _, ch := range input {
+		if isAsciiUpperCase(ch) {
+			if flag == ChIsFirstOfStr {
+				result = append(result, ch)
+				flag = ChIsNextOfUpper
+			} else if flag == ChIsNextOfUpper || flag == ChIsNextOfContdUpper ||
+				(!opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, ch)
+				flag = ChIsNextOfContdUpper
+			} else {
+				result = append(result, '-', ch)
+				flag = ChIsNextOfUpper
+			}
+		} else if isAsciiLowerCase(ch) {
+			if flag == ChIsNextOfContdUpper {
+				n := len(result)
+				prev := result[n-1]
+				result[n-1] = '-'
+				result = append(result, prev, toAsciiUpperCase(ch))
+			} else if flag == ChIsNextOfSepMark ||
+				(opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, '-', toAsciiUpperCase(ch))
+			} else {
+				result = append(result, toAsciiUpperCase(ch))
+			}
+			flag = ChIsOther
+		} else {
+			isKeptChar := false
+			if isAsciiDigit(ch) {
+				isKeptChar = true
+			} else if len(opts.Separators) > 0 {
+				if !strings.ContainsRune(opts.Separators, ch) {
+					isKeptChar = true
+				}
+			} else if len(opts.Keep) > 0 {
+				if strings.ContainsRune(opts.Keep, ch) {
+					isKeptChar = true
+				}
+			}
+
+			if isKeptChar {
+				if opts.SeparateBeforeNonAlphabets {
+					if flag == ChIsFirstOfStr || flag == ChIsNextOfKeptMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '-', ch)
+					}
+				} else {
+					if flag != ChIsNextOfSepMark {
+						result = append(result, ch)
+					} else {
+						result = append(result, '-', ch)
+					}
+				}
+				flag = ChIsNextOfKeptMark
+			} else {
+				if flag != ChIsFirstOfStr {
+					flag = ChIsNextOfSepMark
+				}
+			}
+		}
+	}
+
+	return string(result)
+}
+
+// CobolCase converts the input string to cobol case.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is cobol case.
-//
-// This function targets the upper and lower cases of ASCII alphabets for
-// capitalization, and all characters except ASCII alphabets and ASCII numbers
-// are replaced to hyphens as word separators.
+// It treats the end of a sequence of non-alphabetical characters as a
+// word boundary, but not the beginning.
 func CobolCase(input string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, ch)
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-')
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '-'
-				result = append(result, prev)
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-')
-			}
-			result = append(result, toAsciiUpperCase(ch))
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '-')
-			}
-			result = append(result, ch)
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+	return CobolCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	})
 }
 
-// Converts a string to cobol case using the specified characters as
-// separators.
+// CobolCaseWithSep converts the input string to cobol case with the
+// specified separator characters.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is cobol case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters specified as the second argument of this
-// function are regarded as word separators and are replaced to hyphens.
-func CobolCaseWithSep(input, seps string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, ch)
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-', ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '-'
-				result = append(result, prev, toAsciiUpperCase(ch))
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-', toAsciiUpperCase(ch))
-			default:
-				result = append(result, toAsciiUpperCase(ch))
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
-			switch flag {
-			case ChIsNextOfSepMark:
-				result = append(result, '-', ch)
-			default:
-				result = append(result, ch)
-			}
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use CobolCaseWithOptions instead
+func CobolCaseWithSep(input string, seps string) string {
+	return CobolCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 seps,
+	})
 }
 
-// Converts a string to cobol case using characters other than the specified
-// characters as separators.
+// CobolCaseWithKeep converts the input string to cobol case with the
+// specified characters to be kept.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is cobol case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters other than the specified characters as
-// the second argument of this function are regarded as word separators and
-// are replaced to hyphens.
-func CobolCaseWithKeep(input, keeped string) string {
-	result := make([]rune, 0, len(input)+len(input)/2)
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfContdUpper
-		ChIsNextOfSepMark
-		ChIsNextOfKeepedMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsFirstOfStr:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			case ChIsNextOfUpper, ChIsNextOfContdUpper:
-				result = append(result, ch)
-				flag = ChIsNextOfContdUpper
-			default:
-				result = append(result, '-')
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfContdUpper:
-				n := len(result)
-				prev := result[n-1]
-				result[n-1] = '-'
-				result = append(result, prev, toAsciiUpperCase(ch))
-			case ChIsNextOfSepMark, ChIsNextOfKeepedMark:
-				result = append(result, '-', toAsciiUpperCase(ch))
-			default:
-				result = append(result, toAsciiUpperCase(ch))
-			}
-			flag = ChIsOther
-		} else if isAsciiDigit(ch) || strings.ContainsRune(keeped, ch) {
-			if flag == ChIsNextOfSepMark {
-				result = append(result, '-')
-			}
-			result = append(result, ch)
-			flag = ChIsNextOfKeepedMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfSepMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use CobolCaseWithOptions instead
+func CobolCaseWithKeep(input string, kept string) string {
+	return CobolCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       kept,
+	})
 }

--- a/cobol_case_test.go
+++ b/cobol_case_test.go
@@ -8,216 +8,1251 @@ import (
 	"github.com/sttk/stringcase"
 )
 
-func TestCobolCase_convertCamelCase(t *testing.T) {
-	result := stringcase.CobolCase("abcDefGHIjk")
-	assert.Equal(t, result, "ABC-DEF-GH-IJK")
+func TestCobolCase(t *testing.T) {
+	t.Run("convert camelCase", func(t *testing.T) {
+		result := stringcase.CobolCase("abcDefGHIjk")
+		assert.Equal(t, result, "ABC-DEF-GH-IJK")
+	})
+
+	t.Run("convert PascalCase", func(t *testing.T) {
+		result := stringcase.CobolCase("AbcDefGHIjk")
+		assert.Equal(t, result, "ABC-DEF-GH-IJK")
+	})
+
+	t.Run("convert snake_case", func(t *testing.T) {
+		result := stringcase.CobolCase("abc_def_ghi")
+		assert.Equal(t, result, "ABC-DEF-GHI")
+	})
+
+	t.Run("convert kebab-case", func(t *testing.T) {
+		result := stringcase.CobolCase("abc-def-ghi")
+		assert.Equal(t, result, "ABC-DEF-GHI")
+	})
+
+	t.Run("convert Train-Case", func(t *testing.T) {
+		result := stringcase.CobolCase("Abc-Def-Ghi")
+		assert.Equal(t, result, "ABC-DEF-GHI")
+	})
+
+	t.Run("convert MACRO_CASE", func(t *testing.T) {
+		result := stringcase.CobolCase("ABC_DEF_GHI")
+		assert.Equal(t, result, "ABC-DEF-GHI")
+	})
+
+	t.Run("convert COBOL-CASE", func(t *testing.T) {
+		result := stringcase.CobolCase("ABC-DEF-GHI")
+		assert.Equal(t, result, "ABC-DEF-GHI")
+	})
+
+	t.Run("convert with keeping digits", func(t *testing.T) {
+		result := stringcase.CobolCase("abc123-456defG89HIJklMN12")
+		assert.Equal(t, result, "ABC123-456-DEF-G89-HI-JKL-MN12")
+	})
+
+	t.Run("convert with symbols as separators", func(t *testing.T) {
+		result := stringcase.CobolCase(":.abc~!@def#$ghi%&jk(lm)no/?")
+		assert.Equal(t, result, "ABC-DEF-GHI-JK-LM-NO")
+	})
+
+	t.Run("convert when starting with digit", func(t *testing.T) {
+		result := stringcase.CobolCase("123abc456def")
+		assert.Equal(t, result, "123-ABC456-DEF")
+
+		result = stringcase.CobolCase("123ABC456DEF")
+		assert.Equal(t, result, "123-ABC456-DEF")
+
+		result = stringcase.CobolCase("123Abc456Def")
+		assert.Equal(t, result, "123-ABC456-DEF")
+	})
+
+	t.Run("convert an empty string", func(t *testing.T) {
+		result := stringcase.CobolCase("")
+		assert.Equal(t, result, "")
+	})
 }
 
-func TestCobolCase_convertPascalCase(t *testing.T) {
-	result := stringcase.CobolCase("AbcDefGHIjk")
-	assert.Equal(t, result, "ABC-DEF-GH-IJK")
-}
+func TestCobolCaseWithOptions(t *testing.T) {
+	t.Run("non-alphabets as head of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestCobolCase_convertSnakeCase(t *testing.T) {
-	result := stringcase.CobolCase("abc_def_ghi")
-	assert.Equal(t, result, "ABC-DEF-GHI")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
 
-func TestCobolCase_convertKebabCase(t *testing.T) {
-	result := stringcase.CobolCase("abc-def-ghi")
-	assert.Equal(t, result, "ABC-DEF-GHI")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
 
-func TestCobolCase_convertTrainCase(t *testing.T) {
-	result := stringcase.CobolCase("Abc-Def-Ghi")
-	assert.Equal(t, result, "ABC-DEF-GHI")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCase_convertMacroCase(t *testing.T) {
-	result := stringcase.CobolCase("ABC_DEF_GHI")
-	assert.Equal(t, result, "ABC-DEF-GHI")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCase_convertCobolCase(t *testing.T) {
-	result := stringcase.CobolCase("ABC-DEF-GHI")
-	assert.Equal(t, result, "ABC-DEF-GHI")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCase_keepDigits(t *testing.T) {
-	result := stringcase.CobolCase("abc123-456defG789HIJklMN12")
-	assert.Equal(t, result, "ABC123-456-DEF-G789-HI-JKL-MN12")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TtestCobolCase_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.CobolCase("123abc456def")
-	assert.Equal(t, result, "123-ABC456-DEF")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-	result = stringcase.CobolCase("123ABC456DEF")
-	assert.Equal(t, result, "123-ABC456-DEF")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456DEF-G-89HI-JKL-MN-12")
+		})
 
-func TestCobolCase_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.CobolCase(":.abc~!@def#$ghi%&jk(lm)no/?")
-	assert.Equal(t, result, "ABC-DEF-GHI-JK-LM-NO")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI-JK-LM-NO")
+		})
 
-func TestCobolCase_convertEmpty(t *testing.T) {
-	result := stringcase.CobolCase("")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC-456DEF")
 
-///
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC-456DEF")
 
-func TestCobolCaseWithSep_convertCamelCase(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("abcDefGHIjk", "_-")
-	assert.Equal(t, result, "ABC-DEF-GH-IJK")
-}
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+		})
 
-func TestCobolCaseWithSep_convertPascalCase(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("AbcDefGHIjk", "_-")
-	assert.Equal(t, result, "ABC-DEF-GH-IJK")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestCobolCaseWithSep_convertSnakeCase(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("abc_def_ghi", "_")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+	t.Run("non-alphabets as tail of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-	result = stringcase.CobolCaseWithSep("abc_def_ghi", "-")
-	assert.Equal(t, result, "ABC_-DEF_-GHI")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
 
-func TestCobolCaseWithSep_convertKebabCase(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("abc-def-ghi", "-")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
 
-	result = stringcase.CobolCaseWithSep("abc-def-ghi", "_")
-	assert.Equal(t, result, "ABC--DEF--GHI")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCaseWithSep_convertTrainCase(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-	result = stringcase.CobolCaseWithSep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "ABC--DEF--GHI")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCaseWithSep_convertMacroCase(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-	result = stringcase.CobolCaseWithSep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "ABC_-DEF_-GHI")
-}
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCaseWithSep_convertCobolCase(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456-DEF-G89-HI-JKL-MN12")
+		})
 
-	result = stringcase.CobolCaseWithSep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "ABC--DEF--GHI")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI-JK-LM-NO")
+		})
 
-func TestCobolCaseWithSep_keepDigits(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "ABC123-456-DEF-G789-HI-JKL-MN12")
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
 
-	result = stringcase.CobolCaseWithSep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "ABC123-456-DEF-G789-HI-JKL-MN12")
-}
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
 
-func TestCobolCaseWithSep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("123abc456def", "-")
-	assert.Equal(t, result, "123-ABC456-DEF")
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+		})
 
-	result = stringcase.CobolCaseWithSep("123ABC456DEF", "-")
-	assert.Equal(t, result, "123-ABC456-DEF")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestCobolCaseWithSep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.CobolCaseWithSep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/")
-	assert.Equal(t, result, ".-ABC~!-DEF#-GHI%-JK-LM-NO-?")
-}
+	t.Run("non-alphabets as a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-func TestCobolCaseWithSep_convertEmpty(t *testing.T) {
-	result := stringcase.CobolCaseWithSep("", "-_")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
 
-///
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
 
-func TestCobolCaseWithKeep_convertCamelCase(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("abcDefGHIjk", "_-")
-	assert.Equal(t, result, "ABC-DEF-GH-IJK")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCaseWithKeep_convertPascalCase(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("AbcDefGHIjk", "_-")
-	assert.Equal(t, result, "ABC-DEF-GH-IJK")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCaseWithKeep_convertSnakeCase(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("abc_def_ghi", "-")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-	result = stringcase.CobolCaseWithKeep("abc_def_ghi", "_")
-	assert.Equal(t, result, "ABC_-DEF_-GHI")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCaseWithKeep_convertKebabCase(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("abc-def-ghi", "_")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-	result = stringcase.CobolCaseWithKeep("abc-def-ghi", "-")
-	assert.Equal(t, result, "ABC--DEF--GHI")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12")
+		})
 
-func TestCobolCaseWithKeep_convertTrainCase(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI-JK-LM-NO")
+		})
 
-	result = stringcase.CobolCaseWithKeep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "ABC--DEF--GHI")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
 
-func TestCobolCaseWithKeep_convertMacroCase(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
 
-	result = stringcase.CobolCaseWithKeep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "ABC_-DEF_-GHI")
-}
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+		})
 
-func TestCobolCaseWithKeep_convertCobolCase(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "ABC-DEF-GHI")
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-	result = stringcase.CobolCaseWithKeep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "ABC--DEF--GHI")
-}
+	t.Run("non-alphabets as part of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestCobolCaseWithKeep_keepDigits(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "ABC123-456-DEF-G789-HI-JKL-MN12")
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
 
-	result = stringcase.CobolCaseWithKeep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "ABC123-456-DEF-G789-HI-JKL-MN12")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
 
-func TestCobolCaseWithKeep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("123abc456def", "-")
-	assert.Equal(t, result, "123-ABC456-DEF")
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-	result = stringcase.CobolCaseWithKeep("123abc456def", "_")
-	assert.Equal(t, result, "123-ABC456-DEF")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCaseWithKeep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?")
-	assert.Equal(t, result, ".-ABC~!-DEF#-GHI%-JK-LM-NO-?")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
 
-func TestCobolCaseWithKeep_convertEmpty(t *testing.T) {
-	result := stringcase.CobolCaseWithKeep("", "-_")
-	assert.Equal(t, result, "")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456DEF-G89HI-JKL-MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI-JK-LM-NO")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "-"
+			result = stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC---DEF---GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "-"
+			result = stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456DEF-G-89HI-JKL-MN-12")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456DEF-G-89HI-JKL-MN-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".ABC-~!-DEF-#-GHI-%-JK-LM-NO-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC-456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC-456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "-"
+			result = stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_-DEF_-GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "-"
+			result = stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_-DEF_-GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456-DEF-G89-HI-JKL-MN12")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456-DEF-G89-HI-JKL-MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-ABC~!-DEF#-GHI%-JK-LM-NO-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "-"
+			result = stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-_-DEF-_-GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC---DEF---GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC---DEF---GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "-"
+			result = stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-_-DEF-_-GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC---DEF---GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-ABC-~!-DEF-#-GHI-%-JK-LM-NO-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "-"
+			result = stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "-"
+			result = stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456DEF-G89HI-JKL-MN12")
+
+			opts.Separators = "_"
+			result = stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456DEF-G89HI-JKL-MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".ABC~!-DEF#-GHI%-JK-LM-NO-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC---DEF---GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "_"
+			result = stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-_DEF-_GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456DEF-G-89HI-JKL-MN-12")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456DEF-G-89HI-JKL-MN-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".ABC-~!-DEF-#-GHI-%-JK-LM-NO-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC-456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC-456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "_"
+			result = stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_-DEF_-GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "_"
+			result = stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_-DEF_-GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456-DEF-G89-HI-JKL-MN12")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456-DEF-G89-HI-JKL-MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-ABC~!-DEF#-GHI%-JK-LM-NO-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "_"
+			result = stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-_-DEF-_-GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC---DEF---GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC---DEF---GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "_"
+			result = stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-_-DEF-_-GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC---DEF---GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".-ABC-~!-DEF-#-GHI-%-JK-LM-NO-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC-456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "ABC-DEF-GH-IJK")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "_"
+			result = stringcase.CobolCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "ABC--DEF--GHI")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "_"
+			result = stringcase.CobolCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "ABC_DEF_GHI")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "ABC-DEF-GHI")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456DEF-G89HI-JKL-MN12")
+
+			opts.Keep = "-"
+			result = stringcase.CobolCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "ABC123-456DEF-G89HI-JKL-MN12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.CobolCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".ABC~!-DEF#-GHI%-JK-LM-NO-?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123ABC456DEF")
+
+			result = stringcase.CobolCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123-ABC456-DEF")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CobolCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 }

--- a/example_cobol_case_test.go
+++ b/example_cobol_case_test.go
@@ -7,10 +7,79 @@ import (
 )
 
 func ExampleCobolCase() {
-	cobol := stringcase.CobolCase("foo_bar_baz")
-	fmt.Printf("cobol = %s\n", cobol)
+	cobol := stringcase.CobolCase("fooBarBaz")
+	fmt.Printf("(1) cobol = %s\n", cobol)
+
+	cobol = stringcase.CobolCase("foo-Bar100baz")
+	fmt.Printf("(2) cobol = %s\n", cobol)
 	// Output:
-	// cobol = FOO-BAR-BAZ
+	// (1) cobol = FOO-BAR-BAZ
+	// (2) cobol = FOO-BAR100-BAZ
+}
+
+func ExampleCobolCaseWithOptions() {
+	opts := stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true}
+	cobol := stringcase.CobolCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(1) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(2) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(3) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(4) cobol = %s\n\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Separators: "#"}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(5) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Separators: "#"}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(6) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Separators: "#"}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(7) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Separators: "#"}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(8) cobol = %s\n\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Keep: "%"}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(9) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Keep: "%"}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(a) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Keep: "%"}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(b) cobol = %s\n", cobol)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Keep: "%"}
+	cobol = stringcase.CobolCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(c) cobol = %s\n", cobol)
+	// Output:
+	// (1) cobol = FOO-BAR100-BAZ
+	// (2) cobol = FOO-BAR-100-BAZ
+	// (3) cobol = FOO-BAR-100BAZ
+	// (4) cobol = FOO-BAR100BAZ
+	//
+	// (5) cobol = FOO-BAR100%-BAZ
+	// (6) cobol = FOO-BAR-100%-BAZ
+	// (7) cobol = FOO-BAR-100%BAZ
+	// (8) cobol = FOO-BAR100%BAZ
+	//
+	// (9) cobol = FOO-BAR100%-BAZ
+	// (a) cobol = FOO-BAR-100%-BAZ
+	// (b) cobol = FOO-BAR-100%BAZ
+	// (c) cobol = FOO-BAR100%BAZ
 }
 
 func ExampleCobolCaseWithSep() {


### PR DESCRIPTION
(Related #5)

This PR adds the new function `CobolCaseWithOptions`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`CobolCase` is changed to use this function inside, and both `CobolCaseWithSep` and `CobolCaseWithKeep` are deprecated.