### PR TITLE
new!: added PascalCaseWithOptions, updated PascalCase to use it, and deprecated PascalCaseWithSep/Keep

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -523,6 +523,125 @@ func BenchmarkMacroCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
 	}
 }
 
+// pascal case with options
+
+func BenchmarkPascalCase_nonAlphabetsAsHead(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsTail(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsWord(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsPart(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsHead_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsTail_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsWord_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsPart_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsHead_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsTail_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsWord_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkPascalCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.PascalCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
 // snake case with options
 
 func BenchmarkSnakeCase_nonAlphabetsAsHead(b *testing.B) {

--- a/example_pascal_case_test.go
+++ b/example_pascal_case_test.go
@@ -8,13 +8,82 @@ import (
 
 func ExamplePascalCase() {
 	pascal := stringcase.PascalCase("foo_bar_baz")
-	fmt.Printf("pascal = %s\n", pascal)
+	fmt.Printf("(1) pascal = %s\n", pascal)
+
+	pascal = stringcase.PascalCase("foo-Bar100baz")
+	fmt.Printf("(2) pascal = %s\n", pascal)
 	// Output:
-	// pascal = FooBarBaz
+	// (1) pascal = FooBarBaz
+	// (2) pascal = FooBar100Baz
+}
+
+func ExamplePascalCaseWithOptions() {
+	opts := stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true}
+	pascal := stringcase.PascalCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(1) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(2) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(3) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(4) pascal = %s\n\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Separators: "#"}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(5) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Separators: "#"}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(6) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Separators: "#"}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(7) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Separators: "#"}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(8) pascal = %s\n\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Keep: "%"}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(9) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Keep: "%"}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(a) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Keep: "%"}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(b) pascal = %s\n", pascal)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Keep: "%"}
+	pascal = stringcase.PascalCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(c) pascal = %s\n", pascal)
+	// Output:
+	// (1) pascal = FooBar100Baz
+	// (2) pascal = FooBar100Baz
+	// (3) pascal = FooBar100baz
+	// (4) pascal = FooBar100baz
+	//
+	// (5) pascal = FooBar100%Baz
+	// (6) pascal = FooBar100%Baz
+	// (7) pascal = FooBar100%baz
+	// (8) pascal = FooBar100%baz
+	//
+	// (9) pascal = FooBar100%Baz
+	// (a) pascal = FooBar100%Baz
+	// (b) pascal = FooBar100%baz
+	// (c) pascal = FooBar100%baz
 }
 
 func ExamplePascalCaseWithSep() {
-	pascal := stringcase.PascalCaseWithSep("foo-Bar100%Baz", "- ")
+	pascal := stringcase.PascalCaseWithSep("foo-bar100%baz", "- ")
 	fmt.Printf("pascal = %s\n", pascal)
 	// Output:
 	// pascal = FooBar100%Baz

--- a/pascal_case.go
+++ b/pascal_case.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
@@ -8,181 +8,108 @@ import (
 	"strings"
 )
 
-// Converts a string to pascal case.
+// PascalCaseWithOptions converts the input string to pascal case with the
+// specified options.
+func PascalCaseWithOptions(input string, opts Options) string {
+	result := make([]rune, 0, len(input))
+
+	const (
+		ChIsFirstOfStr = iota
+		ChIsNextOfUpper
+		ChIsNextOfContdUpper
+		ChIsNextOfSepMark
+		ChIsNextOfKeptMark
+		ChIsOther
+	)
+	var flag uint8 = ChIsFirstOfStr
+
+	for _, ch := range input {
+		if isAsciiUpperCase(ch) {
+			if flag == ChIsNextOfUpper || flag == ChIsNextOfContdUpper ||
+				(!opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, toAsciiLowerCase(ch))
+				flag = ChIsNextOfContdUpper
+			} else {
+				result = append(result, ch)
+				flag = ChIsNextOfUpper
+			}
+		} else if isAsciiLowerCase(ch) {
+			if flag == ChIsFirstOfStr {
+				result = append(result, toAsciiUpperCase(ch))
+			} else if flag == ChIsNextOfContdUpper {
+				n := len(result)
+				prev := result[n-1]
+				if isAsciiLowerCase(prev) {
+					prev = toAsciiUpperCase(prev)
+				}
+				result[n-1] = prev
+				result = append(result, ch)
+			} else if flag == ChIsNextOfSepMark ||
+				(opts.SeparateAfterNonAlphabets && flag == ChIsNextOfKeptMark) {
+				result = append(result, toAsciiUpperCase(ch))
+			} else {
+				result = append(result, ch)
+			}
+			flag = ChIsOther
+		} else {
+			isKeptChar := false
+			if isAsciiDigit(ch) {
+				isKeptChar = true
+			} else if len(opts.Separators) > 0 {
+				if !strings.ContainsRune(opts.Separators, ch) {
+					isKeptChar = true
+				}
+			} else if len(opts.Keep) > 0 {
+				if strings.ContainsRune(opts.Keep, ch) {
+					isKeptChar = true
+				}
+			}
+
+			if isKeptChar {
+				result = append(result, ch)
+				flag = ChIsNextOfKeptMark
+			} else {
+				if flag != ChIsFirstOfStr {
+					flag = ChIsNextOfSepMark
+				}
+			}
+		}
+	}
+
+	return string(result)
+}
+
+// PascalCase converts the input string to pascal case.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is pascal case.
-//
-// This function targets the upper and lower cases of ASCII alphabets for
-// capitalization, and all characters except ASCII alphabets and ASCII numbers
-// are eliminated as word separators.
+// It treats the end of a sequence of non-alphabetical characters as a
+// word boundary, but not the beginning.
 func PascalCase(input string) string {
-	result := make([]rune, 0, len(input))
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsNextOfUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				//flag = ChIsNextOfUpper
-			default:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfUpper:
-				n := len(result)
-				prev := result[n-1]
-				if isAsciiLowerCase(prev) {
-					result[n-1] = toAsciiUpperCase(prev)
-				}
-				result = append(result, ch)
-				flag = ChIsOther
-			case ChIsFirstOfStr, ChIsNextOfMark:
-				result = append(result, toAsciiUpperCase(ch))
-				flag = ChIsNextOfUpper
-			default:
-				result = append(result, ch)
-				flag = ChIsOther
-			}
-		} else if isAsciiDigit(ch) {
-			result = append(result, ch)
-			flag = ChIsNextOfMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfMark
-			}
-		}
-	}
-
-	return string(result)
+	return PascalCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	})
 }
 
-// Converts a string to pascal case using the specified characters as
-// separators.
+// PascalCaseWithSep converts the input string to pascal case with the
+// specified separator characters.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is pascal case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters specified as the second argument of this
-// function are regarded as word separators and are eliminated.
-func PascalCaseWithSep(input, seps string) string {
-	result := make([]rune, 0, len(input))
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsNextOfUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				//flag = ChIsNextOfUpper
-			default:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case ChIsNextOfUpper:
-				n := len(result)
-				prev := result[n-1]
-				if isAsciiLowerCase(prev) {
-					result[n-1] = toAsciiUpperCase(prev)
-				}
-				result = append(result, ch)
-				flag = ChIsOther
-			case ChIsFirstOfStr, ChIsNextOfMark:
-				result = append(result, toAsciiUpperCase(ch))
-				flag = ChIsNextOfUpper
-			default:
-				result = append(result, ch)
-				flag = ChIsOther
-			}
-		} else if isAsciiDigit(ch) || !strings.ContainsRune(seps, ch) {
-			result = append(result, ch)
-			flag = ChIsNextOfMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use PascalCaseWithOptions instead
+func PascalCaseWithSep(input string, seps string) string {
+	return PascalCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 seps,
+	})
 }
 
-// Converts a string to pascal case using the specified characters as
-// separators.
+// PascalCaseWithKeep converts the input string to pascal case with the
+// specified characters to be kept.
 //
-// This function takes a string as its argument, then returns a string of which
-// the case style is pascal case.
-//
-// This function targets only the upper and lower cases of ASCII alphabets for
-// capitalization, and the characters specified as the second argument of this
-// function are regarded as word separators and are eliminated.
-func PascalCaseWithKeep(input, keeped string) string {
-	result := make([]rune, 0, len(input))
-
-	const (
-		ChIsFirstOfStr = iota
-		ChIsNextOfUpper
-		ChIsNextOfMark
-		ChIsOther
-	)
-	var flag uint8 = ChIsFirstOfStr
-
-	for _, ch := range input {
-		if isAsciiUpperCase(ch) {
-			switch flag {
-			case ChIsNextOfUpper:
-				result = append(result, toAsciiLowerCase(ch))
-				//flag = ChIsNextOfUpper
-			default:
-				result = append(result, ch)
-				flag = ChIsNextOfUpper
-			}
-		} else if isAsciiLowerCase(ch) {
-			switch flag {
-			case 1:
-				n := len(result)
-				prev := result[n-1]
-				if isAsciiLowerCase(prev) {
-					result[n-1] = toAsciiUpperCase(prev)
-				}
-				result = append(result, ch)
-				flag = ChIsOther
-			case ChIsFirstOfStr, ChIsNextOfMark:
-				result = append(result, toAsciiUpperCase(ch))
-				flag = ChIsNextOfUpper
-			default:
-				result = append(result, ch)
-				flag = ChIsOther
-			}
-		} else if isAsciiDigit(ch) || strings.ContainsRune(keeped, ch) {
-			result = append(result, ch)
-			flag = ChIsNextOfMark
-		} else {
-			if flag != ChIsFirstOfStr {
-				flag = ChIsNextOfMark
-			}
-		}
-	}
-
-	return string(result)
+// Deprecated: Should use PascalCaseWithOptions instead
+func PascalCaseWithKeep(input string, kept string) string {
+	return PascalCaseWithOptions(input, Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       kept,
+	})
 }

--- a/pascal_case_test.go
+++ b/pascal_case_test.go
@@ -8,216 +8,1281 @@ import (
 	"github.com/sttk/stringcase"
 )
 
-func TestPascalCase_convertCamelCase(t *testing.T) {
-	result := stringcase.PascalCase("abcDefGHIjk")
-	assert.Equal(t, result, "AbcDefGhIjk")
+func TestPascalCase(t *testing.T) {
+	t.Run("convert camelCase", func(t *testing.T) {
+		result := stringcase.PascalCase("abcDefGHIjk")
+		assert.Equal(t, result, "AbcDefGhIjk")
+	})
+
+	t.Run("convert PascalCase", func(t *testing.T) {
+		result := stringcase.PascalCase("AbcDefGHIjk")
+		assert.Equal(t, result, "AbcDefGhIjk")
+	})
+
+	t.Run("convert snake_case", func(t *testing.T) {
+		result := stringcase.PascalCase("abc_def_ghi")
+		assert.Equal(t, result, "AbcDefGhi")
+	})
+
+	t.Run("convert kebab-case", func(t *testing.T) {
+		result := stringcase.PascalCase("abc-def-ghi")
+		assert.Equal(t, result, "AbcDefGhi")
+	})
+
+	t.Run("convert Train-Case", func(t *testing.T) {
+		result := stringcase.PascalCase("Abc-Def-Ghi")
+		assert.Equal(t, result, "AbcDefGhi")
+	})
+
+	t.Run("convert MACRO_CASE", func(t *testing.T) {
+		result := stringcase.PascalCase("ABC_DEF_GHI")
+		assert.Equal(t, result, "AbcDefGhi")
+	})
+
+	t.Run("convert COBOL-CASE", func(t *testing.T) {
+		result := stringcase.PascalCase("ABC-DEF-GHI")
+		assert.Equal(t, result, "AbcDefGhi")
+	})
+
+	t.Run("convert with keeping digits", func(t *testing.T) {
+		result := stringcase.PascalCase("abc123-456defG89HIJklMN12")
+		assert.Equal(t, result, "Abc123456DefG89HiJklMn12")
+	})
+
+	t.Run("convert with symbols as separators", func(t *testing.T) {
+		result := stringcase.PascalCase(":.abc~!@def#$ghi%&jk(lm)no/?")
+		assert.Equal(t, result, "AbcDefGhiJkLmNo")
+	})
+
+	t.Run("convert when starting with digit", func(t *testing.T) {
+		result := stringcase.PascalCase("123abc456def")
+		assert.Equal(t, result, "123Abc456Def")
+
+		result = stringcase.PascalCase("123ABC456DEF")
+		assert.Equal(t, result, "123Abc456Def")
+
+		result = stringcase.PascalCase("123Abc456Def")
+		assert.Equal(t, result, "123Abc456Def")
+	})
+
+	t.Run("convert an empty string", func(t *testing.T) {
+		result := stringcase.PascalCase("")
+		assert.Equal(t, result, "")
+	})
 }
 
-func TestPascalCase_convertPascalCase(t *testing.T) {
-	result := stringcase.PascalCase("AbcDefGHIjk")
-	assert.Equal(t, result, "AbcDefGhIjk")
-}
+func TestPascalCaseWithOptions(t *testing.T) {
+	t.Run("non-alphabets as head of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestPascalCase_convertSnakeCase(t *testing.T) {
-	result := stringcase.PascalCase("abc_def_ghi")
-	assert.Equal(t, result, "AbcDefGhi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
 
-func TestPascalCase_convertKebabCase(t *testing.T) {
-	result := stringcase.PascalCase("abc-def-ghi")
-	assert.Equal(t, result, "AbcDefGhi")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
 
-func TestPascalCase_convertTrainCase(t *testing.T) {
-	result := stringcase.PascalCase("Abc-Def-Ghi")
-	assert.Equal(t, result, "AbcDefGhi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCase_convertMacroCase(t *testing.T) {
-	result := stringcase.PascalCase("ABC_DEF_GHI")
-	assert.Equal(t, result, "AbcDefGhi")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCase_convertCobolCase(t *testing.T) {
-	result := stringcase.PascalCase("ABC-DEF-GHI")
-	assert.Equal(t, result, "AbcDefGhi")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCase_keepDigits(t *testing.T) {
-	result := stringcase.PascalCase("abc123-456defG789HIJklMN12")
-	assert.Equal(t, result, "Abc123456DefG789HiJklMn12")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCase_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.PascalCase("123abc456def")
-	assert.Equal(t, result, "123Abc456Def")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-	result = stringcase.PascalCase("123ABC456DEF")
-	assert.Equal(t, result, "123Abc456Def")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456defG89hiJklMn12")
+		})
 
-func TestPascalCase_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.PascalCase(":.abc~!@def#$ghi%&jk(lm)no/?")
-	assert.Equal(t, result, "AbcDefGhiJkLmNo")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "AbcDefGhiJkLmNo")
+		})
 
-func TestPascalCase_convertEmpty(t *testing.T) {
-	result := stringcase.PascalCase("")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
 
-///
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
 
-func TestPascalCaseWithSep_convertCamelCase(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "AbcDefGhIjk")
-}
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
 
-func TestPascalCaseWithSep_convertPascalCase(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("AbcDefGHIjk", "-_")
-	assert.Equal(t, result, "AbcDefGhIjk")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestPascalCaseWithSep_convertSnakeCase(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("abc_def_ghi", "_")
-	assert.Equal(t, result, "AbcDefGhi")
+	t.Run("non-alphabets as tail of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-	result = stringcase.PascalCaseWithSep("abc_def_ghi", "-")
-	assert.Equal(t, result, "Abc_Def_Ghi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
 
-func TestPascalCaseWithSep_convertKebabCase(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("abc-def-ghi", "-")
-	assert.Equal(t, result, "AbcDefGhi")
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
 
-	result = stringcase.PascalCaseWithSep("abc-def-ghi", "_")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCaseWithSep_convertTrainCase(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "AbcDefGhi")
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-	result = stringcase.PascalCaseWithSep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCaseWithSep_convertMacroCase(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "AbcDefGhi")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-	result = stringcase.PascalCaseWithSep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "Abc_Def_Ghi")
-}
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCaseWithSep_convertCobolCase(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "AbcDefGhi")
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456DefG89HiJklMn12")
+		})
 
-	result = stringcase.PascalCaseWithSep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "Abc_Def_Ghi")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "AbcDefGhiJkLmNo")
+		})
 
-func TestPascalCaseWithSep_keepDigits(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "Abc123456DefG789HiJklMn12")
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
 
-	result = stringcase.PascalCaseWithSep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "Abc123-456DefG789HiJklMn12")
-}
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
 
-func TestPascalCaseWithSep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("123abc456def", "_")
-	assert.Equal(t, result, "123Abc456Def")
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
 
-	result = stringcase.PascalCaseWithSep("123ABC456DEF", "_")
-	assert.Equal(t, result, "123Abc456Def")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestPascalCaseWithSep_marksAsSeparators(t *testing.T) {
-	result := stringcase.PascalCaseWithSep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/")
-	assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
-}
+	t.Run("non-alphabets as a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-func TestPascalCaseWithSep_convertEmpty(t *testing.T) {
-	result := stringcase.PascalCaseWithSep("", "-_")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
 
-///
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
 
-func TestPascalCaseWithKeep_convertCamelCase(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("abcDefGHIjk", "-_")
-	assert.Equal(t, result, "AbcDefGhIjk")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCaseWithKeep_convertPascalCase(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("AbcDefGHIjk", "-")
-	assert.Equal(t, result, "AbcDefGhIjk")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCaseWithKeep_convertSnakeCase(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("abc_def_ghi", "-")
-	assert.Equal(t, result, "AbcDefGhi")
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-	result = stringcase.PascalCaseWithKeep("abc_def_ghi", "_")
-	assert.Equal(t, result, "Abc_Def_Ghi")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCaseWithKeep_convertKebabCase(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("abc-def-ghi", "_")
-	assert.Equal(t, result, "AbcDefGhi")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-	result = stringcase.PascalCaseWithKeep("abc-def-ghi", "-")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456DefG89HiJklMn12")
+		})
 
-func TestPascalCaseWithKeep_convertTrainCase(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "AbcDefGhi")
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "AbcDefGhiJkLmNo")
+		})
 
-	result = stringcase.PascalCaseWithKeep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
 
-func TestPascalCaseWithKeep_convertMacroCase(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "AbcDefGhi")
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
 
-	result = stringcase.PascalCaseWithKeep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "Abc_Def_Ghi")
-}
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
 
-func TestPascalCaseWithKeep_convertCobolCase(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "AbcDefGhi")
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-	result = stringcase.PascalCaseWithKeep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "Abc-Def-Ghi")
-}
+	t.Run("non-alphabets as part of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestPascalCaseWithKeep_keepDigits(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "Abc123456DefG789HiJklMn12")
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
 
-	result = stringcase.PascalCaseWithKeep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "Abc123-456DefG789HiJklMn12")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
 
-func TestPascalCaseWithKeep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("123abc456def", "_")
-	assert.Equal(t, result, "123Abc456Def")
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-	result = stringcase.PascalCaseWithKeep("123ABC456DEF", "_")
-	assert.Equal(t, result, "123Abc456Def")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCaseWithKeep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?")
-	assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
 
-func TestPascalCaseWithKeep_convertEmpty(t *testing.T) {
-	result := stringcase.PascalCaseWithKeep("", "-_")
-	assert.Equal(t, result, "")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "AbcDefGhiJkLmNo")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456defG89hiJklMn12")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.PascalCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "Abc123def")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_Def_Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_Def_Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456DefG89HiJklMn12")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456DefG89HiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.PascalCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "Abc123Def")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_Def_Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+
+			opts.Separators = "_"
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_Def_Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456DefG89HiJklMn12")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456DefG89HiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.PascalCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "Abc123Def")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456defG89hiJklMn12")
+
+			opts.Separators = "_"
+			result = stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.PascalCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "Abc123def")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.TrainCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc--def--ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456defG89hiJklMn12")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_Def_Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_Def_Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456DefG89HiJklMn12")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456DefG89HiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_Def_Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_Def_Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456DefG89HiJklMn12")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456DefG89HiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "AbcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.PascalCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "Abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.PascalCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "Abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "AbcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "Abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123456defG89hiJklMn12")
+
+			opts.Keep = "-"
+			result = stringcase.PascalCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "Abc123-456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.PascalCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.PascalCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.PascalCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 }


### PR DESCRIPTION
(Related #5)

This PR adds the new function `PascalCaseWithOptions`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`PascalCase` is changed to use this function inside, and both `PascalCaseWithSep` and `PascalCaseWithKeep` are deprecated.