### PR TITLE
new!: added CamelCaseWithOptions, updated CamelCase to use it, and deprecated CamelCaseWithSep/Keep

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -166,6 +166,125 @@ func BenchmarkTrainCase_withKeep(b *testing.B) {
 	}
 }
 
+// camel case with options
+
+func BenchmarkCamelCase_nonAlphabetsAsHead(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsTail(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsWord(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsPart(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsHead_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsTail_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsWord_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsPart_withSeparators(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Separators:                 "-",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsHead_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsTail_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsWord_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: true,
+		SeparateAfterNonAlphabets:  true,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+func BenchmarkCamelCase_nonAlphabetsAsPart_withKeep(b *testing.B) {
+	opts := stringcase.Options{
+		SeparateBeforeNonAlphabets: false,
+		SeparateAfterNonAlphabets:  false,
+		Keep:                       "%",
+	}
+	for i := 0; i < b.N; i++ {
+		stringcase.CamelCaseWithOptions("foo-bar100%baz", opts)
+	}
+}
+
 // cobol case with options
 
 func BenchmarkCobolCase_nonAlphabetsAsHead(b *testing.B) {

--- a/camel_case.go
+++ b/camel_case.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// CamelCaseWithOptions converts the input string to pascal case with the
+// CamelCaseWithOptions converts the input string to camel case with the
 // specified options.
 func CamelCaseWithOptions(input string, opts Options) string {
 	result := make([]rune, 0, len(input))
@@ -80,7 +80,7 @@ func CamelCaseWithOptions(input string, opts Options) string {
 	return string(result)
 }
 
-// CamelCase converts the input string to pascal case.
+// CamelCase converts the input string to camel case.
 //
 // It treats the end of a sequence of non-alphabetical characters as a
 // word boundary, but not the beginning.
@@ -91,7 +91,7 @@ func CamelCase(input string) string {
 	})
 }
 
-// CamelCaseWithSep converts the input string to pascal case with the
+// CamelCaseWithSep converts the input string to camel case with the
 // specified separator characters.
 //
 // Deprecated: Should use CamelCaseWithOptions instead
@@ -103,7 +103,7 @@ func CamelCaseWithSep(input string, seps string) string {
 	})
 }
 
-// CamelCaseWithKeep converts the input string to pascal case with the
+// CamelCaseWithKeep converts the input string to camel case with the
 // specified characters to be kept.
 //
 // Deprecated: Should use CamelCaseWithOptions instead

--- a/camel_case_test.go
+++ b/camel_case_test.go
@@ -8,216 +8,1281 @@ import (
 	"github.com/sttk/stringcase"
 )
 
-func TestCamelCase_convertCamelCase(t *testing.T) {
-	result := stringcase.CamelCase("abcDefGHIjk")
-	assert.Equal(t, result, "abcDefGhIjk")
+func TestCamelCase(t *testing.T) {
+	t.Run("convert camelCase", func(t *testing.T) {
+		result := stringcase.CamelCase("abcDefGHIjk")
+		assert.Equal(t, result, "abcDefGhIjk")
+	})
+
+	t.Run("convert PascalCase", func(t *testing.T) {
+		result := stringcase.CamelCase("AbcDefGHIjk")
+		assert.Equal(t, result, "abcDefGhIjk")
+	})
+
+	t.Run("convert snake_case", func(t *testing.T) {
+		result := stringcase.CamelCase("abc_def_ghi")
+		assert.Equal(t, result, "abcDefGhi")
+	})
+
+	t.Run("convert kebab-case", func(t *testing.T) {
+		result := stringcase.CamelCase("abc-def-ghi")
+		assert.Equal(t, result, "abcDefGhi")
+	})
+
+	t.Run("convert Train-Case", func(t *testing.T) {
+		result := stringcase.CamelCase("Abc-Def-Ghi")
+		assert.Equal(t, result, "abcDefGhi")
+	})
+
+	t.Run("convert MACRO_CASE", func(t *testing.T) {
+		result := stringcase.CamelCase("ABC_DEF_GHI")
+		assert.Equal(t, result, "abcDefGhi")
+	})
+
+	t.Run("convert COBOL-CASE", func(t *testing.T) {
+		result := stringcase.CamelCase("ABC-DEF-GHI")
+		assert.Equal(t, result, "abcDefGhi")
+	})
+
+	t.Run("convert with keeping digits", func(t *testing.T) {
+		result := stringcase.CamelCase("abc123-456defG89HIJklMN12")
+		assert.Equal(t, result, "abc123456DefG89HiJklMn12")
+	})
+
+	t.Run("convert with symbols as separators", func(t *testing.T) {
+		result := stringcase.CamelCase(":.abc~!@def#$ghi%&jk(lm)no/?")
+		assert.Equal(t, result, "abcDefGhiJkLmNo")
+	})
+
+	t.Run("convert when starting with digit", func(t *testing.T) {
+		result := stringcase.CamelCase("123abc456def")
+		assert.Equal(t, result, "123Abc456Def")
+
+		result = stringcase.CamelCase("123ABC456DEF")
+		assert.Equal(t, result, "123Abc456Def")
+
+		result = stringcase.CamelCase("123Abc456Def")
+		assert.Equal(t, result, "123Abc456Def")
+	})
+
+	t.Run("convert an empty string", func(t *testing.T) {
+		result := stringcase.CamelCase("")
+		assert.Equal(t, result, "")
+	})
 }
 
-func TestCamelCase_convertPascalCase(t *testing.T) {
-	result := stringcase.CamelCase("AbcDefGHIjk")
-	assert.Equal(t, result, "abcDefGhIjk")
-}
+func TestCamelCaseWithOptions(t *testing.T) {
+	t.Run("non-alphabets as head of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestCamelCase_convertSnakeCase(t *testing.T) {
-	result := stringcase.CamelCase("abc_def_ghi")
-	assert.Equal(t, result, "abcDefGhi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
 
-func TestCamelCase_convertKebabCase(t *testing.T) {
-	result := stringcase.CamelCase("abc-def-ghi")
-	assert.Equal(t, result, "abcDefGhi")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
 
-func TestCamelCase_convertTrainCase(t *testing.T) {
-	result := stringcase.CamelCase("Abc-Def-Ghi")
-	assert.Equal(t, result, "abcDefGhi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCase_convertMacroCase(t *testing.T) {
-	result := stringcase.CamelCase("ABC_DEF_GHI")
-	assert.Equal(t, result, "abcDefGhi")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCase_convertCobolCase(t *testing.T) {
-	result := stringcase.CamelCase("ABC-DEF-GHI")
-	assert.Equal(t, result, "abcDefGhi")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCase_keepDigits(t *testing.T) {
-	result := stringcase.CamelCase("abc123-456defG789HIJklMN12")
-	assert.Equal(t, result, "abc123456DefG789HiJklMn12")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCase_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.CamelCase("123abc456def")
-	assert.Equal(t, result, "123Abc456Def")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-	result = stringcase.CamelCase("123ABC456DEF")
-	assert.Equal(t, result, "123Abc456Def")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456defG89hiJklMn12")
+		})
 
-func TestCamelCase_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.CamelCase(":.abc~!@def#$ghi%&jk(lm)no/?")
-	assert.Equal(t, result, "abcDefGhiJkLmNo")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abcDefGhiJkLmNo")
+		})
 
-func TestCamelCase_convertEmpty(t *testing.T) {
-	result := stringcase.CamelCase("")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
 
-///
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
 
-func TestCamelCaseWithSep_convertCamelCase(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("abcDefGHIjk", "_-")
-	assert.Equal(t, result, "abcDefGhIjk")
-}
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
 
-func TestCamelCaseWithSep_convertPascalCase(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("AbcDefGHIjk", "_-")
-	assert.Equal(t, result, "abcDefGhIjk")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestCamelCaseWithSep_convertSnakeCase(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("abc_def_ghi", "_")
-	assert.Equal(t, result, "abcDefGhi")
+	t.Run("non-alphabets as tail of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-	result = stringcase.CamelCaseWithSep("abc_def_ghi", "-")
-	assert.Equal(t, result, "abc_Def_Ghi")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
 
-func TestCamelCaseWithSep_convertKebabCase(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("abc-def-ghi", "-")
-	assert.Equal(t, result, "abcDefGhi")
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
 
-	result = stringcase.CamelCaseWithSep("abc-def-ghi", "_")
-	assert.Equal(t, result, "abc-Def-Ghi")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCaseWithSep_convertTrainCase(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "abcDefGhi")
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-	result = stringcase.CamelCaseWithSep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "abc-Def-Ghi")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCaseWithSep_convertMacroCase(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "abcDefGhi")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-	result = stringcase.CamelCaseWithSep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "abc_Def_Ghi")
-}
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCaseWithSep_convertCobolCase(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "abcDefGhi")
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456DefG89HiJklMn12")
+		})
 
-	result = stringcase.CamelCaseWithSep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "abc-Def-Ghi")
-}
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abcDefGhiJkLmNo")
+		})
 
-func TestCamelCaseWithSep_keepDigits(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "abc123-456DefG789HiJklMn12")
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
 
-	result = stringcase.CamelCaseWithSep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "abc123456DefG789HiJklMn12")
-}
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
 
-func TestCamelCaseWithSep_convertWhenStartingWithDigit(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("123abc456def", "-_")
-	assert.Equal(t, result, "123Abc456Def")
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
 
-	result = stringcase.CamelCaseWithSep("123ABC456DEF", "-_")
-	assert.Equal(t, result, "123Abc456Def")
-}
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-func TestCamelCaseWithSep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.CamelCaseWithSep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/")
-	assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
-}
+	t.Run("non-alphabets as a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
 
-func TestCamelCaseWithSep_convertEmpty(t *testing.T) {
-	result := stringcase.CamelCaseWithSep("", "-_")
-	assert.Equal(t, result, "")
-}
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
 
-///
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
 
-func TestCamelCaseWithKeep_convertCamelCase(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("abcDefGHIjk", "_-")
-	assert.Equal(t, result, "abcDefGhIjk")
-}
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCaseWithKeep_convertPascalCase(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("AbcDefGHIjk", "_-")
-	assert.Equal(t, result, "abcDefGhIjk")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCaseWithKeep_convertSnakeCase(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("abc_def_ghi", "-")
-	assert.Equal(t, result, "abcDefGhi")
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-	result = stringcase.CamelCaseWithKeep("abc_def_ghi", "_")
-	assert.Equal(t, result, "abc_Def_Ghi")
-}
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCaseWithKeep_convertKebabCase(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("abc-def-ghi", "_")
-	assert.Equal(t, result, "abcDefGhi")
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-	result = stringcase.CamelCaseWithKeep("abc-def-ghi", "-")
-	assert.Equal(t, result, "abc-Def-Ghi")
-}
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456DefG89HiJklMn12")
+		})
 
-func TestCamelCaseWithKeep_convertTrainCase(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("Abc-Def-Ghi", "_")
-	assert.Equal(t, result, "abcDefGhi")
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abcDefGhiJkLmNo")
+		})
 
-	result = stringcase.CamelCaseWithKeep("Abc-Def-Ghi", "-")
-	assert.Equal(t, result, "abc-Def-Ghi")
-}
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
 
-func TestCamelCaseWithKeep_convertMacroCase(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("ABC_DEF_GHI", "-")
-	assert.Equal(t, result, "abcDefGhi")
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
 
-	result = stringcase.CamelCaseWithKeep("ABC_DEF_GHI", "_")
-	assert.Equal(t, result, "abc_Def_Ghi")
-}
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
 
-func TestCamelCaseWithKeep_convertCobolCase(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("ABC-DEF-GHI", "_")
-	assert.Equal(t, result, "abcDefGhi")
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 
-	result = stringcase.CamelCaseWithKeep("ABC-DEF-GHI", "-")
-	assert.Equal(t, result, "abc-Def-Ghi")
-}
+	t.Run("non-alphabets as part of a word", func(t *testing.T) {
+		opts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
 
-func TestCamelCaseWithKeep_keepDigits(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("abc123-456defG789HIJklMN12", "_")
-	assert.Equal(t, result, "abc123456DefG789HiJklMn12")
+		t.Run("convert camelCase", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
 
-	result = stringcase.CamelCaseWithKeep("abc123-456defG789HIJklMN12", "-")
-	assert.Equal(t, result, "abc123-456DefG789HiJklMn12")
-}
+		t.Run("convert PascalCase", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
 
-func TestCamelCaseWithKeep_whenStartingWithDigit(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("123abc456def", "_")
-	assert.Equal(t, result, "123Abc456Def")
+		t.Run("convert snake_case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-	result = stringcase.CamelCaseWithKeep("123ABC456DEF", "-")
-	assert.Equal(t, result, "123Abc456Def")
-}
+		t.Run("convert kebab-case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCaseWithKeep_treatMarksAsSeparators(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?")
-	assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
-}
+		t.Run("convert Train-Case", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
 
-func TestCamelCaseWithKeep_convertEmpty(t *testing.T) {
-	result := stringcase.CamelCaseWithKeep("", "-_")
-	assert.Equal(t, result, "")
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, "abcDefGhiJkLmNo")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456defG89hiJklMn12")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.CamelCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123def")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_Def_Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_Def_Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456DefG89HiJklMn12")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456DefG89HiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.CamelCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123Def")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_Def_Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+
+			opts.Separators = "_"
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_Def_Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456DefG89HiJklMn12")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456DefG89HiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.CamelCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123Def")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with separators", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "_"
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "-"
+			result = stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-"
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456defG89hiJklMn12")
+
+			opts.Separators = "_"
+			result = stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = ":@$&()/"
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-_"
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+
+		t.Run("alphabets and numbers in separators are no effect", func(t *testing.T) {
+			opts := origOpts
+			opts.Separators = "-b2"
+			result := stringcase.CamelCaseWithOptions("abc123def", opts)
+			assert.Equal(t, result, "abc123def")
+		})
+	})
+
+	t.Run("non-alphabets as head of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456defG89hiJklMn12")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as tail of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_Def_Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_Def_Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456DefG89HiJklMn12")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456DefG89HiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: true,
+			SeparateAfterNonAlphabets:  true,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_Def_Ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_Def_Ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456DefG89HiJklMn12")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456DefG89HiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".Abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123Abc456Def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
+
+	t.Run("non-alphabets as part of a word and with kept characters", func(t *testing.T) {
+		origOpts := stringcase.Options{
+			SeparateBeforeNonAlphabets: false,
+			SeparateAfterNonAlphabets:  false,
+		}
+
+		t.Run("convert camelCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("abcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert PascalCase", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("AbcDefGHIjk", opts)
+			assert.Equal(t, result, "abcDefGhIjk")
+		})
+
+		t.Run("convert snake_case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.CamelCaseWithOptions("abc_def_ghi", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert kebab-case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("abc-def-ghi", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert Train-Case", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("Abc-Def-Ghi", opts)
+			assert.Equal(t, result, "abc-Def-Ghi")
+		})
+
+		t.Run("convert MACRO_CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-"
+			result := stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "_"
+			result = stringcase.CamelCaseWithOptions("ABC_DEF_GHI", opts)
+			assert.Equal(t, result, "abc_def_ghi")
+		})
+
+		t.Run("convert COBOL-CASE", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abcDefGhi")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("ABC-DEF-GHI", opts)
+			assert.Equal(t, result, "abc-def-ghi")
+		})
+
+		t.Run("convert with keeping digits", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "_"
+			result := stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123456defG89hiJklMn12")
+
+			opts.Keep = "-"
+			result = stringcase.CamelCaseWithOptions("abc123-456defG89HIJklMN12", opts)
+			assert.Equal(t, result, "abc123-456defG89hiJklMn12")
+		})
+
+		t.Run("convert with symbols as separators", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = ".~!#%?"
+			result := stringcase.CamelCaseWithOptions(":.abc~!@def#$ghi%&jk(lm)no/?", opts)
+			assert.Equal(t, result, ".abc~!Def#Ghi%JkLmNo?")
+		})
+
+		t.Run("convert when starting with digit", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("123abc456def", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123ABC456DEF", opts)
+			assert.Equal(t, result, "123abc456def")
+
+			result = stringcase.CamelCaseWithOptions("123Abc456Def", opts)
+			assert.Equal(t, result, "123Abc456Def")
+		})
+
+		t.Run("convert an empty string", func(t *testing.T) {
+			opts := origOpts
+			opts.Keep = "-_"
+			result := stringcase.CamelCaseWithOptions("", opts)
+			assert.Equal(t, result, "")
+		})
+	})
 }

--- a/example_camel_case_test.go
+++ b/example_camel_case_test.go
@@ -8,9 +8,78 @@ import (
 
 func ExampleCamelCase() {
 	camel := stringcase.CamelCase("foo_bar_baz")
-	fmt.Printf("camel = %s\n", camel)
+	fmt.Printf("(1) camel = %s\n", camel)
+
+	camel = stringcase.CamelCase("foo-Bar100baz")
+	fmt.Printf("(2) camel = %s\n", camel)
 	// Output:
-	// camel = fooBarBaz
+	// (1) camel = fooBarBaz
+	// (2) camel = fooBar100Baz
+}
+
+func ExampleCamelCaseWithOptions() {
+	opts := stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true}
+	camel := stringcase.CamelCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(1) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(2) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(3) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100baz", opts)
+	fmt.Printf("(4) camel = %s\n\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Separators: "#"}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(5) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Separators: "#"}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(6) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Separators: "#"}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(7) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Separators: "#"}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(8) camel = %s\n\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: true, Keep: "%"}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(9) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: true, Keep: "%"}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(a) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: true, SeparateAfterNonAlphabets: false, Keep: "%"}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(b) camel = %s\n", camel)
+
+	opts = stringcase.Options{SeparateBeforeNonAlphabets: false, SeparateAfterNonAlphabets: false, Keep: "%"}
+	camel = stringcase.CamelCaseWithOptions("foo#Bar100%baz", opts)
+	fmt.Printf("(c) camel = %s\n", camel)
+	// Output:
+	// (1) camel = fooBar100Baz
+	// (2) camel = fooBar100Baz
+	// (3) camel = fooBar100baz
+	// (4) camel = fooBar100baz
+	//
+	// (5) camel = fooBar100%Baz
+	// (6) camel = fooBar100%Baz
+	// (7) camel = fooBar100%baz
+	// (8) camel = fooBar100%baz
+	//
+	// (9) camel = fooBar100%Baz
+	// (a) camel = fooBar100%Baz
+	// (b) camel = fooBar100%baz
+	// (c) camel = fooBar100%baz
 }
 
 func ExampleCamelCaseWithSep() {


### PR DESCRIPTION
Closes #5

This PR adds the new function `CamelCaseWithOptions`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`CamelCase` is changed to use this function inside, and both `CamelCaseWithSep` and `CamelCaseWithKeep` are deprecated.