### PR TITLE
cicd: upgraded github actions and target go versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gover: ['~1.18', '~1.19', '~1.20', '~1.21', '~1.22', '~1.23']
+        gover: ['~1.18', '~1.19', '~1.20', '~1.21', '~1.22', '~1.23', '~1.24', '~1.25']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.gover }}
 


### PR DESCRIPTION
This PR upgrades the github actions `actions/checkout` to `v5` and `actions/setup-go` to `v5`.

And this PR expands the target go versions for CI to `1.25`.